### PR TITLE
fix: gitignoreにmainを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ bin/
 tmp/
 *.exe
 *.out
+main
 
 # Env
 .env


### PR DESCRIPTION
## 概要
gitignoreにmainを追加

## 変更内容
main.goのビルドファイルがコミットされないよう修正

## 動作確認
なし

## 影響範囲
なし

## 補足
なし