### PR TITLE
feat: ログイン画面へエラーハンドリング適用

### DIFF
--- a/frontend/src/components/TaskAdd.tsx
+++ b/frontend/src/components/TaskAdd.tsx
@@ -1,6 +1,7 @@
 import "./TaskList.css"
 import { useState } from "react";
-import { createTask, ApiError } from "../lib/api";
+import { createTask } from "../lib/api";
+import { ApiError } from "../lib/errors";
 
 type Props = {
   token: string;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -27,10 +27,6 @@ const requestJson = async (url: string, init?: RequestInit) => {
     throw new ApiError(CLIENT_ERROR_CODES.NETWORK_ERROR, "Network error");
   }
 
-  if (!res.ok) {
-    throw new ApiError(ERROR_CODES.INTERNAL_ERROR, "Request failed");
-  }
-
   const json = await parseJsonOrThrow(res);
 
   if (json?.error) {
@@ -41,6 +37,10 @@ const requestJson = async (url: string, init?: RequestInit) => {
       typeof json.error.message === "string" ? json.error.message : code;
 
     throw new ApiError(code, message, json.error.details);
+  }
+
+  if (!res.ok) {
+    throw new ApiError(ERROR_CODES.INTERNAL_ERROR, "Request failed");
   }
 
   return json;
@@ -66,6 +66,25 @@ export const createUser = async (
   });
 
   return json.data.user;
+};
+
+// POST /login
+export const login = async (
+  email: string,
+  password: string
+) => {
+  const json = await requestJson("http://localhost:8080/login", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email,
+      password,
+    }),
+  });
+
+  return json.data;
 };
 
 // GET /me

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,9 +1,13 @@
 import { useState } from "react";
-import type { ErrorDetail } from "../types/error";
+import { useApiError } from "../hooks/useApiError";
 import { Link, useNavigate } from "react-router-dom"
-
 import { AuthCard } from "../components/AuthCard";
 import { FormField } from "../components/FormField";
+import { login } from "../lib/api";
+
+type ValidationDetail = {
+  message: string;
+};
 
 export const Login = () => {
   const [email, setEmail] = useState("");
@@ -12,6 +16,7 @@ export const Login = () => {
   const [fieldErrors, setFieldErrors] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate()
+  const { resolveError } = useApiError();
 
   const handleLogin = async () => {
     setError("");
@@ -19,42 +24,33 @@ export const Login = () => {
     setLoading(true);
     
     try {
-      const res = await fetch("http://localhost:8080/login", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ email, password }),
-      });
+      const data = await login(email, password);
 
-      const json = await res.json();
-
-      if (json.error) {
-        // バリデーションエラー
-        if (json.error.code === "VALIDATION_ERROR") {
-          const details = Array.isArray(json.error.details) ? json.error.details : [];
-          const messages = details.map((d: ErrorDetail) => d.message);
-
-          setFieldErrors(messages);
-          setError("");
-          return;
-        }
-
-        // 認証エラー
-        if (json.error.code === "UNAUTHORIZED") {
-          setError("メールアドレスまたはパスワードが違います");
-          return;
-        }
-
-        // その他
-        setError("ログイン失敗");
-        return;
-      }
-
-      localStorage.setItem("token", json.data.token);
+      localStorage.setItem("token", data.token);
       navigate("/tasks")
-    } catch {
-      setError("通信エラー");
+
+    } catch(err) {
+      const result = resolveError(err);
+
+      switch (result.type) {
+        case "redirect":
+          console.log('redirect');
+          navigate(result.to);
+          break;
+
+        case "validation": {
+          console.log('validation');
+          const details = (result.details as ValidationDetail[] | undefined) ?? [];
+          setFieldErrors(details.map((d) => d.message));
+          setError("");
+          break;
+        }
+
+        case "message":
+          console.log('message');
+          setError(result.message);
+          break;
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -34,20 +34,18 @@ export const Login = () => {
 
       switch (result.type) {
         case "redirect":
-          console.log('redirect');
           navigate(result.to);
           break;
 
         case "validation": {
-          console.log('validation');
-          const details = (result.details as ValidationDetail[] | undefined) ?? [];
-          setFieldErrors(details.map((d) => d.message));
+          if (Array.isArray(result.details)) {
+            setFieldErrors(result.details.map((d) => d.message));
+          }
           setError("");
           break;
         }
 
         case "message":
-          console.log('message');
           setError(result.message);
           break;
       }


### PR DESCRIPTION
## ■ 変更の目的

ログイン画面におけるエラーハンドリングを統一し、
既存の分岐ロジック（instanceof / code判定）を排除して
`useApiError` を利用した一元的な制御へ移行する。

---

## ■ 変更内容

* ログイン処理を `fetch` 直叩きから `login API（requestJson経由）` に変更
* try/catch 内の個別エラー分岐を削除
* `useApiError` の `resolveError` を導入
* `result.type` による分岐へ統一

  * `redirect`：画面遷移
  * `validation`：フィールドエラー表示
  * `message`：汎用エラーメッセージ表示
* バリデーションエラーの details を UI用に変換（message抽出）
* requestJson にてレスポンス処理順を修正

  * `json.error` を優先評価するよう変更（res.ok判定の後ろへ移動）
* `ApiError` の参照元変更に伴い、`TaskAdd.tsx` の古いimportを修正

---

## ■ 影響範囲

* ログイン画面のみ（主変更）
* `TaskAdd.tsx`（import修正のみ、挙動変更なし）
* requestJson の処理順変更により、他APIでもエラーコードの扱いが改善される可能性あり

---

## ■ 動作確認

以下のケースにて動作確認済み：

* 正常ログイン：タスク画面へ遷移し、tokenが保存されること
* 認証エラー（UNAUTHORIZED）：リダイレクト処理が実行されること
* バリデーションエラー（VALIDATION_ERROR）：フィールドエラーが表示されること
* 通信エラー（NETWORK_ERROR）：通信エラーメッセージが表示されること
* 想定外エラー：

  * 非ApiErrorを意図的に発生させ、汎用エラーメッセージが表示されること
  * アプリがクラッシュしないこと
