### PR TITLE
refactor: move tasks API to features/tasks/api

### DIFF
--- a/frontend/src/features/tasks/api/tasksApi.ts
+++ b/frontend/src/features/tasks/api/tasksApi.ts
@@ -1,0 +1,95 @@
+import { requestJson } from "../../../lib/api";
+import type { Task } from "../types/task";
+
+// GET /tasks
+export const fetchTasks = async () => {
+  const token = localStorage.getItem("token");
+
+  console.log('fetch tasks');
+  const json = await requestJson("http://localhost:8080/tasks", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  return json.data.tasks;
+};
+
+// POST /tasks
+export const createTask = async (
+  title: string,
+  dueDate: string
+) => {
+  const token = localStorage.getItem("token");
+
+  const json = await requestJson("http://localhost:8080/tasks", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      title,
+      dueDate: dueDate || null,
+    }),
+  });
+
+  return json.data.task;
+}
+
+// PATCH /tasks/:id (完了チェック)
+export const toggleTaskComplete = async (
+  id: number,
+  current: boolean,
+) => {
+  const token = localStorage.getItem("token");
+
+  const json = await requestJson(`http://localhost:8080/tasks/${id}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      completed: !current,
+    }),
+  });
+
+  return json.data.task;
+}
+
+// PATCH /tasks/:id (タスク編集)
+export const updateTask = async (
+  task: Task,
+) => {
+  const token = localStorage.getItem("token");
+
+  const json = await requestJson(`http://localhost:8080/tasks/${task.id}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      title: task.title,
+      dueDate: task.dueDate,
+      completed: task.completed,
+    }),
+  });
+
+  return json.data.task;
+}
+
+// DELETE /tasks/:id
+export const deleteTask = async (id: number) => {
+  const token = localStorage.getItem("token");
+
+  const json = await requestJson(`http://localhost:8080/tasks/${id}`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  return json;
+}

--- a/frontend/src/features/tasks/components/EditTaskModal.tsx
+++ b/frontend/src/features/tasks/components/EditTaskModal.tsx
@@ -1,7 +1,7 @@
 import "../../../components/common.css"
 import "./EditTaskModal.css"
 import { useEffect, useState } from "react"
-import { updateTask } from "../../../lib/api"
+import { updateTask } from "../api/tasksApi"
 import type { Task } from "../types/task"
 import { useApiError } from "../../../hooks/useApiError";
 import { useNavigate } from "react-router-dom";

--- a/frontend/src/features/tasks/components/TaskAdd.tsx
+++ b/frontend/src/features/tasks/components/TaskAdd.tsx
@@ -1,7 +1,7 @@
 import "../../../components/common.css"
 import "./TaskList.css"
 import { useState } from "react";
-import { createTask } from "../../../lib/api";
+import { createTask } from "../api/tasksApi";
 import { useApiError } from "../../../hooks/useApiError";
 import { useNavigate } from "react-router-dom";
 

--- a/frontend/src/features/tasks/components/TaskList.tsx
+++ b/frontend/src/features/tasks/components/TaskList.tsx
@@ -3,7 +3,8 @@ import "./TaskList.css"
 import { Pencil, Trash2, LogOut } from "lucide-react";
 import { useEffect, useState, useCallback } from "react";
 import type { Task } from "../types/task";
-import { getMe, fetchTasks, toggleTaskComplete, deleteTask } from "../../../lib/api";
+import { getMe } from "../../../lib/api";
+import { fetchTasks, toggleTaskComplete, deleteTask } from "../api/tasksApi";
 import { TaskAdd } from "./TaskAdd";
 import EditTaskModal from "./EditTaskModal"
 import { Navigate, useNavigate } from "react-router-dom"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,3 @@
-import type { Task } from "../features/tasks/types/task";
 import { ERROR_CODES } from "../constants/errorCodes";
 import type { ErrorCode } from "../constants/errorCodes";
 import { CLIENT_ERROR_CODES, ApiError } from "./errors";
@@ -18,7 +17,7 @@ const parseJsonOrThrow = async (res: Response) => {
   }
 };
 
-const requestJson = async (url: string, init?: RequestInit) => {
+export const requestJson = async (url: string, init?: RequestInit) => {
   let res: Response;
 
   try {
@@ -99,97 +98,4 @@ export const getMe = async () => {
   });
 
   return json.data.user;
-}
-
-// GET /tasks
-export const fetchTasks = async () => {
-  const token = localStorage.getItem("token");
-
-  console.log('fetch tasks');
-  const json = await requestJson("http://localhost:8080/tasks", {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  return json.data.tasks;
-};
-
-// POST /tasks
-export const createTask = async (
-  title: string,
-  dueDate: string
-) => {
-  const token = localStorage.getItem("token");
-
-  const json = await requestJson("http://localhost:8080/tasks", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({
-      title,
-      dueDate: dueDate || null,
-    }),
-  });
-
-  return json.data.task;
-}
-
-// PATCH /tasks/:id (完了チェック)
-export const toggleTaskComplete = async (
-  id: number,
-  current: boolean,
-) => {
-  const token = localStorage.getItem("token");
-
-  const json = await requestJson(`http://localhost:8080/tasks/${id}`, {
-    method: "PATCH",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({
-      completed: !current,
-    }),
-  });
-
-  return json.data.task;
-}
-
-// PATCH /tasks/:id (タスク編集)
-export const updateTask = async (
-  task: Task,
-) => {
-  const token = localStorage.getItem("token");
-
-  const json = await requestJson(`http://localhost:8080/tasks/${task.id}`, {
-    method: "PATCH",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({
-      title: task.title,
-      dueDate: task.dueDate,
-      completed: task.completed,
-    }),
-  });
-
-  return json.data.task;
-}
-
-// DELETE /tasks/:id
-export const deleteTask = async (id: number) => {
-  const token = localStorage.getItem("token");
-
-  const json = await requestJson(`http://localhost:8080/tasks/${id}`, {
-    method: "DELETE",
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  return json;
 }


### PR DESCRIPTION
## ■ 目的

tasks専用APIをfeature配下へ整理し、共通API基盤とfeature固有処理の責務を分離する。

Closes #37

---

## ■ 変更内容

- `frontend/src/features/tasks/api/tasksApi.ts` を追加
- `fetchTasks`, `createTask`, `updateTask`, `toggleTaskComplete`, `deleteTask` をtasks feature配下へ切り出し
- `requestJson` を `lib/api.ts` からexportし、共通API基盤として利用
- tasks関連コンポーネントのimportパスを修正

---

## ■ 影響範囲

- タスク一覧取得
- タスク追加
- タスク完了切替
- タスク編集
- タスク削除
- 未ログイン時のタスク画面アクセス

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build`
- `git diff --cached --check`
- ログイン後、今日のタスク画面が表示されることを確認
- タスク一覧取得、追加、完了切替、編集、削除が正常に動作することを確認
- 未ログイン時に `/login` へ遷移することを確認
- ブラウザコンソールエラーがないことを確認

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: tasks専用APIの配置変更とimport修正に限定しており、APIロジック・UI・エラーハンドリングは変更していないため。

---

## ■ 懸念点・補足

- `requestJson` は共通API基盤として `lib/api.ts` に残し、tasks feature APIから参照するためにexportしています。