### PR TITLE
APIクライアントのbaseURL共通化

### DIFF
--- a/frontend/src/features/auth/api/authApi.ts
+++ b/frontend/src/features/auth/api/authApi.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../../../lib/api";
+import { requestJson, API_BASE_URL } from "../../../lib/api";
 
 // POST /users
 export const createUser = async (
@@ -7,7 +7,7 @@ export const createUser = async (
   password: string
 ) => {
   console.log('create user');
-  const json = await requestJson("http://localhost:8080/users", {
+  const json = await requestJson(`${API_BASE_URL}/users`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -27,7 +27,7 @@ export const login = async (
   email: string,
   password: string
 ) => {
-  const json = await requestJson("http://localhost:8080/login", {
+  const json = await requestJson(`${API_BASE_URL}/login`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -46,7 +46,7 @@ export const getMe = async () => {
   const token = localStorage.getItem("token");
 
   console.log('get me');
-  const json = await requestJson("http://localhost:8080/me", {
+  const json = await requestJson(`${API_BASE_URL}/me`, {
     headers: {
       Authorization: `Bearer ${token}`,
     },

--- a/frontend/src/features/tasks/api/tasksApi.ts
+++ b/frontend/src/features/tasks/api/tasksApi.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../../../lib/api";
+import { requestJson, API_BASE_URL } from "../../../lib/api";
 import type { Task } from "../types/task";
 
 // GET /tasks
@@ -6,7 +6,7 @@ export const fetchTasks = async () => {
   const token = localStorage.getItem("token");
 
   console.log('fetch tasks');
-  const json = await requestJson("http://localhost:8080/tasks", {
+  const json = await requestJson(`${API_BASE_URL}/tasks`, {
     headers: {
       Authorization: `Bearer ${token}`,
     },
@@ -22,7 +22,7 @@ export const createTask = async (
 ) => {
   const token = localStorage.getItem("token");
 
-  const json = await requestJson("http://localhost:8080/tasks", {
+  const json = await requestJson(`${API_BASE_URL}/tasks`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -44,7 +44,7 @@ export const toggleTaskComplete = async (
 ) => {
   const token = localStorage.getItem("token");
 
-  const json = await requestJson(`http://localhost:8080/tasks/${id}`, {
+  const json = await requestJson(`${API_BASE_URL}/tasks/${id}`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
@@ -64,7 +64,7 @@ export const updateTask = async (
 ) => {
   const token = localStorage.getItem("token");
 
-  const json = await requestJson(`http://localhost:8080/tasks/${task.id}`, {
+  const json = await requestJson(`${API_BASE_URL}/tasks/${task.id}`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
@@ -84,7 +84,7 @@ export const updateTask = async (
 export const deleteTask = async (id: number) => {
   const token = localStorage.getItem("token");
 
-  const json = await requestJson(`http://localhost:8080/tasks/${id}`, {
+  const json = await requestJson(`${API_BASE_URL}/tasks/${id}`, {
     method: "DELETE",
     headers: {
       Authorization: `Bearer ${token}`,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,6 +2,8 @@ import { ERROR_CODES } from "../constants/errorCodes";
 import type { ErrorCode } from "../constants/errorCodes";
 import { CLIENT_ERROR_CODES, ApiError } from "./errors";
 
+export const API_BASE_URL = "http://localhost:8080";
+
 const isErrorCode = (value: unknown): value is ErrorCode => {
   return (
     typeof value === "string" &&


### PR DESCRIPTION
## ■ 目的

APIクライアントにおける baseURL を共通化し、各API関数から `http://localhost:8080` の直接記述を排除する。

Closes #44

---

## ■ 変更内容

- `frontend/src/lib/api.ts` に `API_BASE_URL` を定義
- auth API の各URLを `API_BASE_URL` 参照に置換
- tasks API の各URLを `API_BASE_URL` 参照に置換

---

## ■ 影響範囲

- ログイン、ユーザー登録、ユーザー情報取得 API
- タスク一覧取得、作成、完了切替、編集、削除 API
- UI、エラーハンドリング、token処理、型定義への変更なし

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build`
- 手動確認
  - テストユーザーでログインできること
  - タスク一覧が表示されること
  - タスクを追加できること
  - 完了チェックを切り替えられること
  - タスクを編集できること
  - タスクを削除できること
  - ブラウザ Console に API エラーが出ていないこと

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: API URL 文字列を定数参照に置き換えたのみで、処理ロジックやUIは変更していないため。

---

## ■ 懸念点・補足

- 画面押下の自動テスト環境整備は別Issueで管理予定。