### PR TITLE
APIクライアントのtoken取得処理を共通化

### DIFF
--- a/frontend/src/features/auth/api/authApi.ts
+++ b/frontend/src/features/auth/api/authApi.ts
@@ -1,4 +1,4 @@
-import { requestJson, API_BASE_URL } from "../../../lib/api";
+import { requestJson, API_BASE_URL, getToken } from "../../../lib/api";
 
 // POST /users
 export const createUser = async (
@@ -43,7 +43,7 @@ export const login = async (
 
 // GET /me
 export const getMe = async () => {
-  const token = localStorage.getItem("token");
+  const token = getToken();
 
   console.log('get me');
   const json = await requestJson(`${API_BASE_URL}/me`, {

--- a/frontend/src/features/tasks/api/tasksApi.ts
+++ b/frontend/src/features/tasks/api/tasksApi.ts
@@ -1,9 +1,9 @@
-import { requestJson, API_BASE_URL } from "../../../lib/api";
+import { requestJson, API_BASE_URL, getToken } from "../../../lib/api";
 import type { Task } from "../types/task";
 
 // GET /tasks
 export const fetchTasks = async () => {
-  const token = localStorage.getItem("token");
+  const token = getToken();
 
   console.log('fetch tasks');
   const json = await requestJson(`${API_BASE_URL}/tasks`, {
@@ -20,7 +20,7 @@ export const createTask = async (
   title: string,
   dueDate: string
 ) => {
-  const token = localStorage.getItem("token");
+  const token = getToken();
 
   const json = await requestJson(`${API_BASE_URL}/tasks`, {
     method: "POST",
@@ -42,7 +42,7 @@ export const toggleTaskComplete = async (
   id: number,
   current: boolean,
 ) => {
-  const token = localStorage.getItem("token");
+  const token = getToken();
 
   const json = await requestJson(`${API_BASE_URL}/tasks/${id}`, {
     method: "PATCH",
@@ -62,7 +62,7 @@ export const toggleTaskComplete = async (
 export const updateTask = async (
   task: Task,
 ) => {
-  const token = localStorage.getItem("token");
+  const token = getToken();
 
   const json = await requestJson(`${API_BASE_URL}/tasks/${task.id}`, {
     method: "PATCH",
@@ -82,7 +82,7 @@ export const updateTask = async (
 
 // DELETE /tasks/:id
 export const deleteTask = async (id: number) => {
-  const token = localStorage.getItem("token");
+  const token = getToken();
 
   const json = await requestJson(`${API_BASE_URL}/tasks/${id}`, {
     method: "DELETE",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,6 +4,8 @@ import { CLIENT_ERROR_CODES, ApiError } from "./errors";
 
 export const API_BASE_URL = "http://localhost:8080";
 
+export const getToken = () => localStorage.getItem("token");
+
 const isErrorCode = (value: unknown): value is ErrorCode => {
   return (
     typeof value === "string" &&


### PR DESCRIPTION
## ■ 目的

APIクライアントにおける token 取得処理を共通化し、各API関数から `localStorage.getItem("token")` の直接呼び出しを排除する。

Closes #46

---

## ■ 変更内容

- `frontend/src/lib/api.ts` に `getToken()` を追加
- `features/auth/api` の token 取得を `getToken()` 呼び出しへ置換
- `features/tasks/api` の token 取得を `getToken()` 呼び出しへ置換

---

## ■ 影響範囲

- フロントエンド API クライアント
  - `GET /me`
  - task API の認証付きリクエスト

UI、APIレスポンス構造、エラーハンドリング、Authorizationヘッダー生成方式は変更していません。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `rg 'localStorage\\.getItem\\(\"token\"\\)' frontend/src`
  - 該当なし
- `npm run build`
  - 成功
- ブラウザで一通りの動作確認
  - 問題なし

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: token の取得元と戻り値は変更せず、直接呼び出しを共通関数経由に置き換えたのみのため。

---

## ■ 懸念点・補足

- ブラウザで一通りの動作確認を行い、問題ないことを確認済みです。
- 将来的に token の保存・削除も整理する場合は、`tokenStorage` などへの責務分離を別Issueで検討するとよさそうです。