### PR TITLE
Authorizationヘッダー生成処理を共通化

### DIFF
--- a/frontend/src/features/auth/api/authApi.ts
+++ b/frontend/src/features/auth/api/authApi.ts
@@ -1,4 +1,4 @@
-import { requestJson, API_BASE_URL, getToken } from "../../../lib/api";
+import { requestJson, API_BASE_URL, getAuthHeaders } from "../../../lib/api";
 
 // POST /users
 export const createUser = async (
@@ -43,13 +43,9 @@ export const login = async (
 
 // GET /me
 export const getMe = async () => {
-  const token = getToken();
-
   console.log('get me');
   const json = await requestJson(`${API_BASE_URL}/me`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
+    headers: getAuthHeaders(),
   });
 
   return json.data.user;

--- a/frontend/src/features/tasks/api/tasksApi.ts
+++ b/frontend/src/features/tasks/api/tasksApi.ts
@@ -1,15 +1,11 @@
-import { requestJson, API_BASE_URL, getToken } from "../../../lib/api";
+import { requestJson, API_BASE_URL, getAuthHeaders } from "../../../lib/api";
 import type { Task } from "../types/task";
 
 // GET /tasks
 export const fetchTasks = async () => {
-  const token = getToken();
-
   console.log('fetch tasks');
   const json = await requestJson(`${API_BASE_URL}/tasks`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
+    headers: getAuthHeaders(),
   });
 
   return json.data.tasks;
@@ -20,13 +16,11 @@ export const createTask = async (
   title: string,
   dueDate: string
 ) => {
-  const token = getToken();
-
   const json = await requestJson(`${API_BASE_URL}/tasks`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
+      ...getAuthHeaders(),
     },
     body: JSON.stringify({
       title,
@@ -42,13 +36,11 @@ export const toggleTaskComplete = async (
   id: number,
   current: boolean,
 ) => {
-  const token = getToken();
-
   const json = await requestJson(`${API_BASE_URL}/tasks/${id}`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
+      ...getAuthHeaders(),
     },
     body: JSON.stringify({
       completed: !current,
@@ -62,13 +54,11 @@ export const toggleTaskComplete = async (
 export const updateTask = async (
   task: Task,
 ) => {
-  const token = getToken();
-
   const json = await requestJson(`${API_BASE_URL}/tasks/${task.id}`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
+      ...getAuthHeaders(),
     },
     body: JSON.stringify({
       title: task.title,
@@ -82,13 +72,9 @@ export const updateTask = async (
 
 // DELETE /tasks/:id
 export const deleteTask = async (id: number) => {
-  const token = getToken();
-
   const json = await requestJson(`${API_BASE_URL}/tasks/${id}`, {
     method: "DELETE",
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
+    headers: getAuthHeaders(),
   });
 
   return json;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,10 @@ export const API_BASE_URL = "http://localhost:8080";
 
 export const getToken = () => localStorage.getItem("token");
 
+export const getAuthHeaders = () => ({
+  Authorization: `Bearer ${getToken()}`,
+});
+
 const isErrorCode = (value: unknown): value is ErrorCode => {
   return (
     typeof value === "string" &&


### PR DESCRIPTION
## ■ 目的

APIクライアントにおける Authorization ヘッダー生成処理を共通化し、各API関数から `Authorization: Bearer ...` の組み立て処理を排除する。

Closes #48

---

## ■ 変更内容

- `frontend/src/lib/api.ts` に `getAuthHeaders()` を追加
- `getMe` の Authorization ヘッダー生成を `getAuthHeaders()` 呼び出しへ置換
- tasks API の Authorization ヘッダー生成を `getAuthHeaders()` 呼び出しへ置換
- `Content-Type` は既存通り各API関数側で指定

---

## ■ 影響範囲

- フロントエンド API クライアント
  - `GET /me`
  - task API の認証付きリクエスト

UI、token取得仕様、token保存方式、APIレスポンス構造、エラーハンドリングは変更していません。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `rg 'Authorization:\\s*`Bearer' frontend/src`
  - `frontend/src/lib/api.ts` の共通関数のみ該当
- `npm run build`
  - 成功
- ブラウザで一通りの動作確認
  - 問題なし

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: Authorization ヘッダーの生成結果は維持し、各API関数内の組み立て処理を共通関数呼び出しへ置き換えたのみのため。

---

## ■ 懸念点・補足

- `Content-Type` は今回の対象外のため共通化していません。