### PR TITLE
Content-Typeヘッダー指定を共通化

### DIFF
--- a/frontend/src/features/auth/api/authApi.ts
+++ b/frontend/src/features/auth/api/authApi.ts
@@ -1,4 +1,9 @@
-import { requestJson, API_BASE_URL, getAuthHeaders } from "../../../lib/api";
+import {
+  requestJson,
+  API_BASE_URL,
+  getAuthHeaders,
+  getJsonHeaders,
+} from "../../../lib/api";
 
 // POST /users
 export const createUser = async (
@@ -9,9 +14,7 @@ export const createUser = async (
   console.log('create user');
   const json = await requestJson(`${API_BASE_URL}/users`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
+    headers: getJsonHeaders(),
     body: JSON.stringify({
       name: name,
       email: email,
@@ -29,9 +32,7 @@ export const login = async (
 ) => {
   const json = await requestJson(`${API_BASE_URL}/login`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
+    headers: getJsonHeaders(),
     body: JSON.stringify({
       email,
       password,

--- a/frontend/src/features/tasks/api/tasksApi.ts
+++ b/frontend/src/features/tasks/api/tasksApi.ts
@@ -1,4 +1,9 @@
-import { requestJson, API_BASE_URL, getAuthHeaders } from "../../../lib/api";
+import {
+  requestJson,
+  API_BASE_URL,
+  getAuthHeaders,
+  getJsonHeaders,
+} from "../../../lib/api";
 import type { Task } from "../types/task";
 
 // GET /tasks
@@ -19,7 +24,7 @@ export const createTask = async (
   const json = await requestJson(`${API_BASE_URL}/tasks`, {
     method: "POST",
     headers: {
-      "Content-Type": "application/json",
+      ...getJsonHeaders(),
       ...getAuthHeaders(),
     },
     body: JSON.stringify({
@@ -39,7 +44,7 @@ export const toggleTaskComplete = async (
   const json = await requestJson(`${API_BASE_URL}/tasks/${id}`, {
     method: "PATCH",
     headers: {
-      "Content-Type": "application/json",
+      ...getJsonHeaders(),
       ...getAuthHeaders(),
     },
     body: JSON.stringify({
@@ -57,7 +62,7 @@ export const updateTask = async (
   const json = await requestJson(`${API_BASE_URL}/tasks/${task.id}`, {
     method: "PATCH",
     headers: {
-      "Content-Type": "application/json",
+      ...getJsonHeaders(),
       ...getAuthHeaders(),
     },
     body: JSON.stringify({

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,6 +10,10 @@ export const getAuthHeaders = () => ({
   Authorization: `Bearer ${getToken()}`,
 });
 
+export const getJsonHeaders = () => ({
+  "Content-Type": "application/json",
+});
+
 const isErrorCode = (value: unknown): value is ErrorCode => {
   return (
     typeof value === "string" &&


### PR DESCRIPTION
## ■ 目的

APIクライアントにおける `Content-Type: application/json` の指定を共通化し、各API関数内の重複記述を減らす。

Closes #50

---

## ■ 変更内容

- `frontend/src/lib/api.ts` に `getJsonHeaders()` を追加
- auth API の `Content-Type: application/json` 指定を `getJsonHeaders()` 呼び出しへ置換
- tasks API の POST / PATCH の `Content-Type: application/json` 指定を `getJsonHeaders()` 呼び出しへ置換
- 認証付きリクエストでは既存の `getAuthHeaders()` と組み合わせる形に変更

---

## ■ 影響範囲

- フロントエンド API クライアント
  - `POST /users`
  - `POST /login`
  - `POST /tasks`
  - `PATCH /tasks/:id`

GET / DELETE、Authorizationヘッダー生成、token取得仕様、APIレスポンス構造、エラーハンドリング、UI は変更していません。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `rg 'Content-Type' frontend/src`
  - `frontend/src/lib/api.ts` の共通関数のみ該当
- `npm run build`
  - 成功
- ブラウザで一通りの動作確認
  - 問題なし

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: `Content-Type: application/json` の生成結果は維持し、各API関数内の重複記述を共通関数呼び出しへ置き換えたのみのため。

---

## ■ 懸念点・補足

- GET / DELETE の挙動は変更していません。
- `Content-Type` 以外のヘッダー生成仕様は変更していません。