### PR TITLE
chore: add gitattributes lf policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary


### PR DESCRIPTION
## ■ 目的

リポジトリにおける改行コード方針を LF として明示し、環境差による不要な差分や Git 警告を防ぐ。

Closes #53

---

## ■ 変更内容

- リポジトリルートに `.gitattributes` を追加
- テキストファイルの改行コード方針として LF を指定
- 画像ファイルを binary として定義

---

## ■ 影響範囲

- Git の改行コード取り扱い
- 実行時のロジック・UI・API仕様への影響なし

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `git diff origin/main --name-status`
  - `.gitattributes` の追加のみであることを確認
- `git diff --cached --check`
  - whitespace error なしを確認
- 動作確認済み（ユーザー確認）

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: `.gitattributes` の新規追加のみで、既存ファイルの改行コード変換・ロジック変更・UI変更を行っていないため。

---

## ■ 懸念点・補足

- 改行コード変換は本PRの対象外
- 必要な場合は別Issueで対象範囲を限定して実施する
