### PR TITLE
TaskAddのエラー処理をuseApiErrorの返却形式に合わせる

### DIFF
--- a/frontend/src/features/tasks/components/TaskAdd.tsx
+++ b/frontend/src/features/tasks/components/TaskAdd.tsx
@@ -38,12 +38,18 @@ export const TaskAdd = ({ onTaskAdded }: Props) => {
           navigate(result.to);
           break;
 
-        case "validation":
-          alert("入力内容に問題があります");
+        case "validation": {
+          const message =
+            result.details.length > 0
+              ? result.details.map((detail) => detail.message).join("\n")
+              : result.message;
+
+          alert(message);
           break;
+        }
 
         case "message":
-          alert("タスク追加失敗");
+          alert(result.message);
           break;
       }
     }


### PR DESCRIPTION
## ■ 目的

TaskAdd画面のエラー処理を、整理済みの `useApiError` の返却形式に合わせて統一する。

Closes #69

---

## ■ 変更内容

- `TaskAdd.tsx` の `validation` 分岐で `result.details` を優先し、空の場合は `result.message` をalertに表示
- `message` 分岐で固定文言ではなく `result.message` をalertに表示
- `redirect` 分岐とタスク追加成功時の既存処理は維持

---

## ■ 影響範囲

- `frontend/src/features/tasks/components/TaskAdd.tsx`
- タスク追加時のAPIエラー表示

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build` 成功
- Browser Check
  - TaskAddでタイトルのみのタスク追加が成功し、`POST /tasks` が `201` になることを確認
  - TaskAddで日付ありタスク追加が成功し、request body が `dueDate: "2026-05-05"` になることを確認
  - validation応答を差し替え、`result.details` 由来のalert表示を確認
  - message応答を差し替え、`result.message` 由来のalert表示を確認
  - token削除後、`/tasks` から `/login` へ遷移することを確認
  - console error / runtime exception なし

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: 変更対象はTaskAddのAPIエラー時alert文言の組み立てに限定しており、成功処理・UI構造・API呼び出しは変更していないため。

---

## ■ 懸念点・補足

- validation / message のエラーケースは、ブラウザ上でTaskAddのPOST応答を差し替えて分岐確認した。
- 日付入力は `type="date"` の値として `YYYY-MM-DD` 文字列を設定して確認した。