### PR TITLE
ブラウザ確認手順を軽量な差分確認向けに補足する

### DIFF
--- a/docs/codex-browser-check.md
+++ b/docs/codex-browser-check.md
@@ -49,13 +49,19 @@ Backendのroot pathが `404` を返しても、HTTP応答が返っている場�
 Repository rootで以下を実行する。
 
 ```bash
-docker compose up --build -d
+docker compose up -d
 ```
 
 起動後、以下にアクセスできることを確認する。
 
 - Frontend: `http://localhost:5173`
 - Backend: `http://localhost:8080`
+
+Dockerfile、依存関係、`package-lock.json`、Go modulesなど、コンテナイメージに影響する変更を確認する場合のみ再ビルドする。
+
+```bash
+docker compose up --build -d
+```
 
 ## Codex Browser Operation Requirements
 
@@ -105,17 +111,23 @@ Invoke-RestMethod http://127.0.0.1:9335/json/version
 ### Operation Notes
 
 - 入力確認はDOMの `value` を直接変更するだけではなく、実入力イベントまたはReactに伝わる入力イベントで行う
-- Reactの入力確認では、native setterで値を更新し、`InputEvent` を発火させるとstateへ反映されやすい
+- Reactの入力確認では、native setterで値を更新し、入力前の値を `_valueTracker` に反映してから `input` / `change` イベントを発火させるとstateへ反映されやすい
+- `input type="date"` の `value` は文字列として扱う。指定値は `YYYY-MM-DD` 形式（例: `2026-05-05`）を使い、`YYYY/MM/DD` 形式は使わない
 - ボタン押下はDOMの `click()` ではなく、座標に対するマウスイベントで確認する
 - `Input.dispatchMouseEvent` の応答待ちで停止する場合は、座標を算出したうえで対象要素へ `MouseEvent` を発火する代替手順を検討する
 - console確認では `Runtime.consoleAPICalled` と `Runtime.exceptionThrown` を確認する
 - API確認では `Network.responseReceived` を確認する
+- 小さなエラー分岐確認では、CDPの `Fetch.enable` による応答差し替えが不安定な場合がある。その場合はページ内で `window.fetch` と `window.alert` を一時的に差し替え、対象コンポーネントの分岐に渡る値を確認する
 - CDP操作をPowerShellのWebSocketで直接行うと不安定な場合があるため、外部依存を追加せずに済む場合はNode標準の `WebSocket` を使う
 - PowerShell経由でNodeスクリプトを実行する場合、日本語文字列の判定が文字化けすることがあるため、判定は可能な限りURL、CSS selector、ASCIIのテストデータで行う
 
 ## Change-Specific Checks
 
-標準シナリオに加えて、変更内容に応じた確認を行う。
+標準シナリオから変更に関係する操作を選び、既存挙動が壊れていないことを確認する。
+そのうえで、変更内容に応じた追加確認を行う。
+
+変更が小さい場合でも、関連する標準シナリオは省略しない。
+一方で、変更と関係しない標準シナリオまで毎回すべて実行する必要はない。
 
 特に以下を確認する。
 
@@ -125,6 +137,11 @@ Invoke-RestMethod http://127.0.0.1:9335/json/version
 - 変更した処理の前後で維持すべき既存挙動
 
 確認しない場合は、理由を結果に残す。
+
+例:
+
+- alert文言の組み立てだけを変更した場合は、成功系を1ケース確認し、エラー分岐は対象API応答を差し替えて確認する
+- 日付入力そのものを変更していない場合は、`type="date"` を日付UIとして操作することにこだわらず、`YYYY-MM-DD` 文字列がrequest bodyに入ることを確認する
 
 ## Check Points
 


### PR DESCRIPTION
## ■ 目的

Codex Browser Check Guideを、日常の差分確認で詰まりにくい手順に整える。

---

## ■ 変更内容

- 通常起動手順を `docker compose up -d` に変更
- `--build` が必要なケースを明記
- React controlled inputの値反映手順を補足
- `input type="date"` は `YYYY-MM-DD` 文字列で扱うことを追記
- CDPの `Fetch.enable` が不安定な場合の代替として、`window.fetch` / `window.alert` の一時差し替えを追記
- Change-Specific Checksで、関連する標準シナリオは省略せず、変更固有の追加確認を行う方針に整理

---

## ■ 影響範囲

- `docs/codex-browser-check.md`
- Codexによるローカルブラウザ確認手順

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- ドキュメント差分を確認
- 手順書のみの変更のため、アプリケーションの追加動作確認は未実施
- 直前のTaskAdd確認で詰まった内容をもとに、起動手順・React input・date input・エラー応答差し替えの注意点を反映

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: ドキュメントのみの変更であり、アプリケーションコードや実行時挙動には影響しないため。

---

## ■ 懸念点・補足

- PRテンプレートの動作確認チェックは、ドキュメント変更として差分確認済みの意味でチェックしている。
- アプリケーションコード変更は含まない。