### PR TITLE
EditTaskModalのエラー表示をフォーム系に統一

### DIFF
--- a/frontend/src/features/tasks/components/EditTaskModal.tsx
+++ b/frontend/src/features/tasks/components/EditTaskModal.tsx
@@ -13,28 +13,18 @@ type Props = {
   onUpdated: () => void
 }
 
+type ModalContentProps = {
+  onClose: () => void
+  task: Task
+  onUpdated: () => void
+}
+
 export default function EditTaskModal({
   isOpen,
   onClose,
   task,
   onUpdated,
 }: Props) {
-  const [title, setTitle] = useState("");
-  const [dueDate, setDueDate] = useState<string | null>(null);
-  const [completed, setCompleted] = useState(false);
-  const { resolveError } = useApiError();
-  const navigate = useNavigate();
-
-  // 初期値セット
-  useEffect(() => {
-    if (isOpen && task) {
-      setTitle(task.title);
-      setDueDate(task.dueDate);
-      setCompleted(task.completed);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [task])
-
   useEffect(() => {
     const handleEsc = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
@@ -51,7 +41,33 @@ export default function EditTaskModal({
 
   if (!isOpen || !task) return null
 
+  return (
+    <EditTaskModalContent
+      key={task.id}
+      onClose={onClose}
+      task={task}
+      onUpdated={onUpdated}
+    />
+  )
+}
+
+function EditTaskModalContent({
+  onClose,
+  task,
+  onUpdated,
+}: ModalContentProps) {
+  const [title, setTitle] = useState(task.title);
+  const [dueDate, setDueDate] = useState<string | null>(task.dueDate);
+  const [completed, setCompleted] = useState(task.completed);
+  const [error, setError] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<string[]>([]);
+  const { resolveError } = useApiError();
+  const navigate = useNavigate();
+
   const handleSave = async () => {
+    setError("");
+    setFieldErrors([]);
+
     const payload: Task = {
       id: task.id,
       title,
@@ -72,10 +88,19 @@ export default function EditTaskModal({
           navigate(result.to);
           break;
 
-        case "validation":
+        case "validation": {
+          const messages =
+            result.details.length > 0
+              ? result.details.map((detail) => detail.message)
+              : [result.message];
+
+          setFieldErrors(messages);
+          setError("");
           break;
+        }
 
         case "message":
+          setError(result.message);
           break;
       }
     }
@@ -116,6 +141,16 @@ export default function EditTaskModal({
             <span>完了</span>
           </div>
         </div>
+
+        {fieldErrors.length > 0 && (
+          <ul style={{ color: "#d33", margin: "8px 0", paddingLeft: "20px" }}>
+            {fieldErrors.map((message, index) => (
+              <li key={`${message}-${index}`}>{message}</li>
+            ))}
+          </ul>
+        )}
+
+        {error && <p style={{ color: "#d33", margin: "8px 0" }}>{error}</p>}
 
         <div className="modal-actions">
           <button className="cancel" onClick={onClose}>


### PR DESCRIPTION
## ■ 目的

EditTaskModal のエラー処理および表示挙動を、`useApiError` の返却形式と既存フォーム系画面に合わせて統一する。

Closes #78

---

## ■ 変更内容

- EditTaskModal のフォーム部分を内部コンポーネント `EditTaskModalContent` として分離
- モーダルフォームに `error` / `fieldErrors` state を追加
- 保存時の `catch` を `result.type` ベースで整理
- validation エラーを複数メッセージのリスト表示へ変更
- message エラーを単一エラー表示へ変更
- effect 内でフォーム state を同期更新していた処理をやめ、初期値を `useState` の初期値として扱う形へ整理

---

## ■ 影響範囲

- EditTaskModal のタスク編集フォーム
- EditTaskModal の validation / message / redirect エラー処理

TaskList、TaskAdd、Login、Register、API処理には変更なし。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build` 成功
- `npm run lint` 成功
- Browser Check 実施
  - モーダル初期値表示: OK
  - 編集成功: モーダルが閉じ、一覧のタイトルが更新されること
  - validation detailsあり: 複数メッセージが `<li>` で表示され、モーダルが維持されること
  - validation details空: fallback message が `<li>` で表示されること
  - message error: 単一エラーが表示され、モーダルが維持されること
  - redirect error: `/login` へ遷移すること
  - alert が発生しないこと
  - 想定外の console error がないこと

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: 変更範囲は EditTaskModal の内部実装とエラー表示処理に限定しており、API仕様や他画面の処理は変更していないため。

---

## ■ 懸念点・補足

`ModalContentProps` と `EditTaskModalContent` はこのファイル内だけで使う内部実装として定義している。
