### PR TITLE
TaskList の今日タスク抽出ロジックを分離する

### DIFF
--- a/frontend/src/features/tasks/components/TaskList.tsx
+++ b/frontend/src/features/tasks/components/TaskList.tsx
@@ -9,19 +9,12 @@ import { TaskAdd } from "./TaskAdd";
 import EditTaskModal from "./EditTaskModal"
 import { Navigate, useNavigate } from "react-router-dom"
 import { useApiError } from "../../../hooks/useApiError";
+import { filterTodayTasks } from "../utils/taskFilters";
 
 type User = {
   id: number;
   name: string;
   email: string;
-};
-
-const getTodayString = () => {
-  const today = new Date();
-  const yyyy = today.getFullYear();
-  const mm = String(today.getMonth() + 1).padStart(2, "0");
-  const dd = String(today.getDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
 };
 
 // 今日のタスク一覧
@@ -111,11 +104,7 @@ export const TaskList = () => {
     }
   }
 
-  const todayStr = getTodayString();
-
-  const todayTasks = tasks.filter(
-    (task) => task.dueDate === todayStr
-  );
+  const todayTasks = filterTodayTasks(tasks);
 
   const openModal = (task: Task) => {
     setSelectedTask(task)

--- a/frontend/src/features/tasks/utils/taskFilters.ts
+++ b/frontend/src/features/tasks/utils/taskFilters.ts
@@ -1,0 +1,17 @@
+import type { Task } from "../types/task";
+
+const getTodayString = () => {
+  const today = new Date();
+  const yyyy = today.getFullYear();
+  const mm = String(today.getMonth() + 1).padStart(2, "0");
+  const dd = String(today.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+};
+
+export const filterTodayTasks = (tasks: Task[]) => {
+  const todayStr = getTodayString();
+
+  return tasks.filter(
+    (task) => task.dueDate === todayStr
+  );
+};


### PR DESCRIPTION
## ■ 目的

TaskList.tsx 内にある今日タスク抽出ロジックを分離し、TaskList の責務を軽くする。

Closes #83

---

## ■ 変更内容

- `frontend/src/features/tasks/utils/taskFilters.ts` を追加
- 既存の今日の日付文字列生成と `dueDate === todayStr` による抽出条件を `filterTodayTasks` に移動
- `TaskList.tsx` では `filterTodayTasks(tasks)` を利用する形に変更

---

## ■ 影響範囲

- 今日のタスク一覧表示
- `TaskList.tsx` の今日タスク抽出処理

API呼び出し、状態管理、UI構造、日付仕様は変更していません。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [ ] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build`: OK
- Edgeゲストモード + CDPで確認
  - ユーザー登録: OK (`POST /users`: 201)
  - ログイン: OK (`POST /login`: 200)
  - 今日の日付 `2026-05-05` のタスク追加: OK (`POST /tasks`: 201)
  - 未来日 `2099-12-31` のタスク追加: OK (`POST /tasks`: 201)
  - 今日タスクのみ表示されること: OK
  - 未来日タスクが表示されないこと: OK
  - リロード後も今日タスクのみ表示されること: OK
  - `GET /me`: 200
  - `GET /tasks`: 200
  - console error / warning: なし
  - runtime exception: なし

エラーケースは、今回の変更が純粋な抽出ロジック分離であり、APIエラー制御や入力バリデーションを変更していないため未確認です。

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: 既存の `getTodayString` と `dueDate === todayStr` の条件をそのまま `taskFilters.ts` に移動したのみで、表示条件・UI・API呼び出しは変更していないため。

---

## ■ 懸念点・補足

- 日付仕様、タイムゾーン対応、表示条件の改善は対象外です。
- エラーケースは変更範囲外のため未確認です。