### PR TITLE
TaskList のタスク行表示を TaskListItem に分離する

### DIFF
--- a/frontend/src/features/tasks/components/TaskList.tsx
+++ b/frontend/src/features/tasks/components/TaskList.tsx
@@ -1,12 +1,13 @@
 import "../../../components/common.css"
 import "./TaskList.css"
-import { Pencil, Trash2, LogOut } from "lucide-react";
+import { LogOut } from "lucide-react";
 import { useEffect, useState, useCallback } from "react";
 import type { Task } from "../types/task";
 import { getMe } from "../../auth/api/authApi";
 import { fetchTasks, toggleTaskComplete, deleteTask } from "../api/tasksApi";
 import { TaskAdd } from "./TaskAdd";
 import EditTaskModal from "./EditTaskModal"
+import { TaskListItem } from "./TaskListItem";
 import { Navigate, useNavigate } from "react-router-dom"
 import { useApiError } from "../../../hooks/useApiError";
 import { filterTodayTasks } from "../utils/taskFilters";
@@ -139,30 +140,13 @@ export const TaskList = () => {
       <div className="task-container">
         <div className="task-list">
           {todayTasks.map((task) => (
-            <div key={task.id} className="task-row">
-              <div className="task-left">
-                <input
-                  type="checkbox"
-                  checked={task.completed}
-                  onChange={() => handleToggle(task.id, task.completed)}
-                />
-
-                <span className="task-title" title={task.title}>
-                  {task.title}
-                </span>
-              </div>
-
-              <div className="task-actions">
-                <button className="button-with-icon" onClick={() => openModal(task)}>
-                  <Pencil size={16} />
-                  編集
-                </button>
-                <button className="button-with-icon delete" onClick={() => handleDelete(task.id)}>
-                  <Trash2 size={16} />
-                  削除
-                </button>
-              </div>
-            </div>
+            <TaskListItem
+              key={task.id}
+              task={task}
+              onToggle={handleToggle}
+              onEdit={openModal}
+              onDelete={handleDelete}
+            />
           ))}
         </div>
 

--- a/frontend/src/features/tasks/components/TaskListItem.tsx
+++ b/frontend/src/features/tasks/components/TaskListItem.tsx
@@ -1,0 +1,43 @@
+import { Pencil, Trash2 } from "lucide-react";
+import type { Task } from "../types/task";
+
+type Props = {
+  task: Task;
+  onToggle: (id: number, current: boolean) => void;
+  onEdit: (task: Task) => void;
+  onDelete: (id: number) => void;
+};
+
+export const TaskListItem = ({
+  task,
+  onToggle,
+  onEdit,
+  onDelete,
+}: Props) => {
+  return (
+    <div className="task-row">
+      <div className="task-left">
+        <input
+          type="checkbox"
+          checked={task.completed}
+          onChange={() => onToggle(task.id, task.completed)}
+        />
+
+        <span className="task-title" title={task.title}>
+          {task.title}
+        </span>
+      </div>
+
+      <div className="task-actions">
+        <button className="button-with-icon" onClick={() => onEdit(task)}>
+          <Pencil size={16} />
+          編集
+        </button>
+        <button className="button-with-icon delete" onClick={() => onDelete(task.id)}>
+          <Trash2 size={16} />
+          削除
+        </button>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## ■ 目的

TaskList.tsx 内にあるタスク1件分の表示処理を `TaskListItem` として分離し、TaskList の JSX 責務を軽くする。

Closes #86

---

## ■ 変更内容

- `frontend/src/features/tasks/components/TaskListItem.tsx` を追加
- `todayTasks.map(...)` 内にあったタスク行 JSX を `TaskListItem` に移動
- `TaskList.tsx` から `TaskListItem` に `task` / `onToggle` / `onEdit` / `onDelete` を渡す形に変更
- `Pencil` / `Trash2` icon の利用箇所を `TaskListItem` 側へ移動

完了切替・編集・削除の処理本体は `TaskList.tsx` に残しています。

---

## ■ 影響範囲

- 今日のタスク一覧のタスク行表示
- 完了切替、編集、削除ボタンのイベント通知

API呼び出し、状態管理、CSS、UI文言、className は変更していません。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [ ] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build`: OK
- Edgeゲストモード + CDPで確認
  - ユーザー登録: OK (`POST /users`: 201)
  - ログイン: OK (`POST /login`: 200)
  - 今日の日付 `2026-05-05` のタスク追加: OK (`POST /tasks`: 201)
  - タスク行の表示構造: OK
  - 完了切替: OK (`PATCH /tasks/:id`: 200)
  - 編集後の表示反映: OK (`PATCH /tasks/:id`: 200)
  - 削除後の非表示反映: OK (`DELETE /tasks/:id`: 200)
  - `GET /me`: 200
  - `GET /tasks`: 200
  - console error / warning: なし
  - runtime exception: なし

エラーケースは、今回の変更がタスク行表示コンポーネントの分離であり、APIエラー制御や入力バリデーションを変更していないため未確認です。

Logout は今回の変更範囲外かつ既知Issueありのため未確認です。

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: 既存のタスク行 JSX を `TaskListItem` に移動し、親からイベント処理を props で渡す構造にしたのみで、API呼び出し・状態管理・CSS・表示文言は変更していないため。

---

## ■ 懸念点・補足

- `TaskListItem` は表示とイベント通知のみ担当し、完了切替・編集・削除の処理本体は `TaskList.tsx` に残しています。