### PR TITLE
TaskList のヘッダー表示を TaskListHeader に分離する

### DIFF
--- a/frontend/src/features/tasks/components/TaskList.tsx
+++ b/frontend/src/features/tasks/components/TaskList.tsx
@@ -1,12 +1,12 @@
 import "../../../components/common.css"
 import "./TaskList.css"
-import { LogOut } from "lucide-react";
 import { useEffect, useState, useCallback } from "react";
 import type { Task } from "../types/task";
 import { getMe } from "../../auth/api/authApi";
 import { fetchTasks, toggleTaskComplete, deleteTask } from "../api/tasksApi";
 import { TaskAdd } from "./TaskAdd";
 import EditTaskModal from "./EditTaskModal"
+import { TaskListHeader } from "./TaskListHeader";
 import { TaskListItem } from "./TaskListItem";
 import { Navigate, useNavigate } from "react-router-dom"
 import { useApiError } from "../../../hooks/useApiError";
@@ -112,30 +112,19 @@ export const TaskList = () => {
     setIsOpen(true)
   }
 
+  const handleLogout = () => {
+    localStorage.removeItem("token");
+    setUser(null);
+    window.location.href = "/login";
+  }
+
   if (!token) {
     return <Navigate to="/login" />;
   }
 
   return (
     <div className="task-wrapper">
-      <div className="header">
-        <div className="header-top">
-          <h1>今日のタスク</h1>
-          <button 
-            className="button-with-icon logout"
-            onClick={() => {
-              localStorage.removeItem("token");
-              setUser(null);
-              window.location.href = "/login";
-            }}
-          >
-            <LogOut size={14} />
-            ログアウト
-          </button>
-        </div>
-        
-        <p className="greeting">こんにちは、{user?.name}さん</p>
-      </div>
+      <TaskListHeader user={user} onLogout={handleLogout} />
 
       <div className="task-container">
         <div className="task-list">

--- a/frontend/src/features/tasks/components/TaskListHeader.tsx
+++ b/frontend/src/features/tasks/components/TaskListHeader.tsx
@@ -1,0 +1,34 @@
+import { LogOut } from "lucide-react";
+
+type User = {
+  id: number;
+  name: string;
+  email: string;
+};
+
+type Props = {
+  user: User | null;
+  onLogout: () => void;
+};
+
+export const TaskListHeader = ({
+  user,
+  onLogout,
+}: Props) => {
+  return (
+    <div className="header">
+      <div className="header-top">
+        <h1>今日のタスク</h1>
+        <button
+          className="button-with-icon logout"
+          onClick={onLogout}
+        >
+          <LogOut size={14} />
+          ログアウト
+        </button>
+      </div>
+
+      <p className="greeting">こんにちは、{user?.name}さん</p>
+    </div>
+  );
+};


### PR DESCRIPTION
## ■ 目的

TaskList.tsx 内にあるヘッダー表示を `TaskListHeader` として分離し、TaskList の JSX 責務を軽くする。

Closes #88

---

## ■ 変更内容

- `frontend/src/features/tasks/components/TaskListHeader.tsx` を追加
- `TaskList.tsx` 内にあったヘッダー JSX を `TaskListHeader` に移動
- `TaskList.tsx` から `TaskListHeader` に `user` / `onLogout` を渡す形に変更
- `LogOut` icon の利用箇所を `TaskListHeader` 側へ移動
- ログアウト処理本体は `TaskList.tsx` の `handleLogout` に残す形に変更

`localStorage.removeItem("token")`、`setUser(null)`、`window.location.href = "/login"` の処理内容は変更していません。

---

## ■ 影響範囲

- TaskList 画面のヘッダー表示
- ユーザー名表示
- ログアウトボタンのイベント通知

API呼び出し、状態管理、CSS、UI文言、className は変更していません。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [ ] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build`: OK
- Edgeゲストモード + CDPで確認
  - ユーザー登録: OK (`POST /users`: 201)
  - ログイン: OK (`POST /login`: 200)
  - タスク画面ヘッダー表示: OK
  - ログアウトボタン表示: OK
  - ユーザー名表示: OK
  - ログアウト後 `/login` 遷移: OK
  - ログアウト後 token 削除: OK
  - `GET /me`: 200
  - `GET /tasks`: 200
  - console error / warning: なし
  - runtime exception: なし

エラーケースは、今回の変更がヘッダー表示コンポーネントの分離であり、APIエラー制御や入力バリデーションを変更していないため未確認です。

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: 既存のヘッダー JSX を `TaskListHeader` に移動し、親から `user` とログアウト処理を props で渡す構造にしたのみで、API呼び出し・状態管理・CSS・表示文言は変更していないため。

---

## ■ 懸念点・補足

- `TaskListHeader` は表示とログアウトイベント通知のみ担当し、ログアウト処理本体は `TaskList.tsx` に残しています。