### PR TITLE
TaskList のデータ取得状態を useTaskListData に分離する

### DIFF
--- a/frontend/src/features/tasks/components/TaskList.tsx
+++ b/frontend/src/features/tasks/components/TaskList.tsx
@@ -1,9 +1,8 @@
 import "../../../components/common.css"
 import "./TaskList.css"
-import { useEffect, useState, useCallback } from "react";
+import { useState } from "react";
 import type { Task } from "../types/task";
-import { getMe } from "../../auth/api/authApi";
-import { fetchTasks, toggleTaskComplete, deleteTask } from "../api/tasksApi";
+import { toggleTaskComplete, deleteTask } from "../api/tasksApi";
 import { TaskAdd } from "./TaskAdd";
 import EditTaskModal from "./EditTaskModal"
 import { TaskListHeader } from "./TaskListHeader";
@@ -11,53 +10,22 @@ import { TaskListItem } from "./TaskListItem";
 import { Navigate, useNavigate } from "react-router-dom"
 import { useApiError } from "../../../hooks/useApiError";
 import { filterTodayTasks } from "../utils/taskFilters";
-
-type User = {
-  id: number;
-  name: string;
-  email: string;
-};
+import { useTaskListData } from "../hooks/useTaskListData";
 
 // 今日のタスク一覧
 export const TaskList = () => {
-  const [tasks, setTasks] = useState<Task[]>([]);
   const [isOpen, setIsOpen] = useState(false)
   const [selectedTask, setSelectedTask] = useState<Task | null>(null)
-  const [user, setUser] = useState<User | null>(null);
   const { resolveError } = useApiError();
   const navigate = useNavigate();
+  const {
+    user,
+    tasks,
+    loadTasks,
+    clearUser,
+  } = useTaskListData();
 
   const token = localStorage.getItem("token");
-
-  const loadTasks = useCallback(async () => {
-    if (!token) return;
-
-    try {
-      const me = await getMe();
-      setUser(me);
-
-      const tasks = await fetchTasks();
-      setTasks(tasks);
-    } catch (err) {
-      const result = resolveError(err);
-
-      switch (result.type) {
-        case "redirect":
-          navigate(result.to);
-          break;
-        case "message":
-          console.error(result.message);
-          break;
-        case "validation":
-          console.error(result.message);
-          break;
-      }
-    }
-  }, [navigate, resolveError, token]);
-
-  useEffect(() => {
-    void Promise.resolve().then(loadTasks);
-  }, [loadTasks]);
 
   const handleToggle = async (id: number, current: boolean) => {
     try {
@@ -114,7 +82,7 @@ export const TaskList = () => {
 
   const handleLogout = () => {
     localStorage.removeItem("token");
-    setUser(null);
+    clearUser();
     window.location.href = "/login";
   }
 

--- a/frontend/src/features/tasks/hooks/useTaskListData.ts
+++ b/frontend/src/features/tasks/hooks/useTaskListData.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getMe } from "../../auth/api/authApi";
+import { fetchTasks } from "../api/tasksApi";
+import type { Task } from "../types/task";
+import { useApiError } from "../../../hooks/useApiError";
+
+type User = {
+  id: number;
+  name: string;
+  email: string;
+};
+
+export const useTaskListData = () => {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [user, setUser] = useState<User | null>(null);
+  const { resolveError } = useApiError();
+  const navigate = useNavigate();
+
+  const token = localStorage.getItem("token");
+
+  const loadTasks = useCallback(async () => {
+    if (!token) return;
+
+    try {
+      const me = await getMe();
+      setUser(me);
+
+      const tasks = await fetchTasks();
+      setTasks(tasks);
+    } catch (err) {
+      const result = resolveError(err);
+
+      switch (result.type) {
+        case "redirect":
+          navigate(result.to);
+          break;
+        case "message":
+          console.error(result.message);
+          break;
+        case "validation":
+          console.error(result.message);
+          break;
+      }
+    }
+  }, [navigate, resolveError, token]);
+
+  useEffect(() => {
+    void Promise.resolve().then(loadTasks);
+  }, [loadTasks]);
+
+  const clearUser = () => {
+    setUser(null);
+  };
+
+  return {
+    user,
+    tasks,
+    loadTasks,
+    clearUser,
+  };
+};


### PR DESCRIPTION
## ■ 目的

TaskList.tsx が保持しているデータ取得状態と `loadTasks` を `useTaskListData` に分離し、TaskList の責務を画面制御・表示組み立てに寄せる。

Closes #90

---

## ■ 変更内容

- `frontend/src/features/tasks/hooks/useTaskListData.ts` を追加
- `tasks` / `user` state、`loadTasks`、初期取得、`useApiError` を使ったデータ取得エラー解決処理を hook に移動
- `TaskList.tsx` では `useTaskListData` の戻り値を使用
- ログアウト時の user クリアを `clearUser()` 経由に変更

---

## ■ 影響範囲

- タスク一覧画面の初期データ取得
- タスク追加・編集・完了切替・削除後の再取得
- ログアウト時の user state クリア

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build` 成功
- Edge ゲストモード + CDP で以下を確認
  - 未ログイン状態で `/tasks` へアクセスすると `/login` に遷移する
  - ユーザー登録後、ログイン画面へ遷移する
  - ログイン後、`/me` で取得したユーザー名がヘッダーに表示される
  - 今日の日付でタスクを追加すると一覧に表示される
  - 完了切替後、再取得された状態が画面に反映される
  - 編集後、モーダルが閉じて更新後タイトルが一覧に表示される
  - 削除後、対象タスクが一覧から消える
  - ログアウト後、token が削除され `/login` に遷移する

確認した主な API:

- `POST /users`: `201`
- `POST /login`: `200`
- `GET /me`: `200`
- `GET /tasks`: `200`
- `POST /tasks`: `201`
- `PATCH /tasks/:id`: `200`
- `DELETE /tasks/:id`: `200`

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: 既存の `loadTasks` 処理を hook へ移動するのみで、API呼び出し順序・再取得タイミング・ログアウト遷移方法・UIは維持しているため。

---

## ■ 懸念点・補足

- `204` の API ログは CORS preflight として確認し、実APIレスポンスとは分けて確認済み
- 想定外の `console.error` / `console.warn` / runtime exception は確認されていない