### PR TITLE
TaskList のタスク操作処理を useTaskListData に分離する

### DIFF
--- a/frontend/src/features/tasks/components/TaskList.tsx
+++ b/frontend/src/features/tasks/components/TaskList.tsx
@@ -2,13 +2,11 @@ import "../../../components/common.css"
 import "./TaskList.css"
 import { useState } from "react";
 import type { Task } from "../types/task";
-import { toggleTaskComplete, deleteTask } from "../api/tasksApi";
 import { TaskAdd } from "./TaskAdd";
 import EditTaskModal from "./EditTaskModal"
 import { TaskListHeader } from "./TaskListHeader";
 import { TaskListItem } from "./TaskListItem";
-import { Navigate, useNavigate } from "react-router-dom"
-import { useApiError } from "../../../hooks/useApiError";
+import { Navigate } from "react-router-dom"
 import { filterTodayTasks } from "../utils/taskFilters";
 import { useTaskListData } from "../hooks/useTaskListData";
 
@@ -16,61 +14,23 @@ import { useTaskListData } from "../hooks/useTaskListData";
 export const TaskList = () => {
   const [isOpen, setIsOpen] = useState(false)
   const [selectedTask, setSelectedTask] = useState<Task | null>(null)
-  const { resolveError } = useApiError();
-  const navigate = useNavigate();
   const {
     user,
     tasks,
     loadTasks,
     clearUser,
+    toggleTask,
+    deleteTaskById,
   } = useTaskListData();
 
   const token = localStorage.getItem("token");
-
-  const handleToggle = async (id: number, current: boolean) => {
-    try {
-      await toggleTaskComplete(id, current);
-      await loadTasks();
-    } catch (err) {
-      const result = resolveError(err);
-
-      switch (result.type) {
-        case "redirect":
-          navigate(result.to);
-          break;
-        case "validation":
-          alert(result.message);
-          break;
-        case "message":
-          alert(result.message);
-          break;
-      }
-    }
-  };
 
   const handleDelete = async (id: number) => {
     const confirmed = window.confirm("このタスクを削除しますか？");
 
     if (!confirmed) return;
 
-    try {
-      await deleteTask(id);
-      await loadTasks();
-    } catch (err) {
-      const result = resolveError(err);
-
-      switch (result.type) {
-        case "redirect":
-          navigate(result.to);
-          break;
-        case "validation":
-          alert(result.message);
-          break;
-        case "message":
-          alert(result.message);
-          break;
-      }
-    }
+    await deleteTaskById(id);
   }
 
   const todayTasks = filterTodayTasks(tasks);
@@ -100,7 +60,7 @@ export const TaskList = () => {
             <TaskListItem
               key={task.id}
               task={task}
-              onToggle={handleToggle}
+              onToggle={toggleTask}
               onEdit={openModal}
               onDelete={handleDelete}
             />

--- a/frontend/src/features/tasks/hooks/useTaskListData.ts
+++ b/frontend/src/features/tasks/hooks/useTaskListData.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getMe } from "../../auth/api/authApi";
-import { fetchTasks } from "../api/tasksApi";
+import { deleteTask, fetchTasks, toggleTaskComplete } from "../api/tasksApi";
 import type { Task } from "../types/task";
 import { useApiError } from "../../../hooks/useApiError";
 
@@ -53,10 +53,54 @@ export const useTaskListData = () => {
     setUser(null);
   };
 
+  const toggleTask = async (id: number, current: boolean) => {
+    try {
+      await toggleTaskComplete(id, current);
+      await loadTasks();
+    } catch (err) {
+      const result = resolveError(err);
+
+      switch (result.type) {
+        case "redirect":
+          navigate(result.to);
+          break;
+        case "validation":
+          alert(result.message);
+          break;
+        case "message":
+          alert(result.message);
+          break;
+      }
+    }
+  };
+
+  const deleteTaskById = async (id: number) => {
+    try {
+      await deleteTask(id);
+      await loadTasks();
+    } catch (err) {
+      const result = resolveError(err);
+
+      switch (result.type) {
+        case "redirect":
+          navigate(result.to);
+          break;
+        case "validation":
+          alert(result.message);
+          break;
+        case "message":
+          alert(result.message);
+          break;
+      }
+    }
+  }
+
   return {
     user,
     tasks,
     loadTasks,
     clearUser,
+    toggleTask,
+    deleteTaskById,
   };
 };


### PR DESCRIPTION
## ■ 目的

TaskList.tsx に残っているタスク操作API処理を `useTaskListData` に分離し、TaskList の責務を画面イベント制御・表示組み立てに寄せる。

Closes #92

---

## ■ 変更内容

- `useTaskListData` に完了切替用の `toggleTask` を追加
- `useTaskListData` に削除API実行用の `deleteTaskById` を追加
- `toggleTaskComplete(id, current)` → `loadTasks()` → エラー処理の流れを hook 側へ移動
- `deleteTask(id)` → `loadTasks()` → エラー処理の流れを hook 側へ移動
- `TaskList.tsx` 側では hook から受け取った関数を使用
- 削除確認 `window.confirm("このタスクを削除しますか？")` は `TaskList.tsx` 側に維持

---

## ■ 影響範囲

- タスク一覧画面の完了切替
- タスク一覧画面の削除
- 完了切替・削除後のタスク一覧再取得

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build` 成功
- Edge ゲストモード + CDP で以下を確認
  - 未ログイン状態で `/tasks` へアクセスすると `/login` に遷移する
  - ユーザー登録後、ログイン画面へ遷移する
  - ログイン後、初期取得でユーザー名とタスク画面が表示される
  - 今日の日付でタスクを追加すると一覧に表示される
  - 完了切替後、`PATCH /tasks/:id` のあと再取得されチェック状態が画面に反映される
  - 削除時に `confirm` が呼ばれ、`DELETE /tasks/:id` のあと再取得され一覧から消える
  - ログアウト後、token が削除され `/login` に遷移する

確認した主な API:

- `POST /users`: `201`
- `POST /login`: `200`
- `GET /me`: `200`
- `GET /tasks`: `200`
- `POST /tasks`: `201`
- `PATCH /tasks/:id`: `200`
- `DELETE /tasks/:id`: `200`

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: 既存の完了切替・削除API処理を hook へ移動するのみで、API呼び出し内容・再取得タイミング・削除確認メッセージ・UIは維持しているため。

---

## ■ 懸念点・補足

- `204` の API ログは CORS preflight として確認し、実APIレスポンスとは分けて確認済み
- 想定外の `console.error` / `console.warn` / runtime exception は確認されていない