### PR TITLE
useTaskListData の初期取得とタスク再取得を分離する

### DIFF
--- a/frontend/src/features/tasks/components/TaskList.tsx
+++ b/frontend/src/features/tasks/components/TaskList.tsx
@@ -17,7 +17,7 @@ export const TaskList = () => {
   const {
     user,
     tasks,
-    loadTasks,
+    reloadTasks,
     clearUser,
     toggleCompletion,
     removeTask,
@@ -67,13 +67,13 @@ export const TaskList = () => {
           ))}
         </div>
 
-        <TaskAdd onTaskAdded={loadTasks} />
+        <TaskAdd onTaskAdded={reloadTasks} />
 
         <EditTaskModal
           isOpen={isOpen}
           onClose={() => setIsOpen(false)}
           task={selectedTask}
-          onUpdated={loadTasks}
+          onUpdated={reloadTasks}
         />
       </div>
     </div>

--- a/frontend/src/features/tasks/hooks/useTaskListData.ts
+++ b/frontend/src/features/tasks/hooks/useTaskListData.ts
@@ -19,13 +19,10 @@ export const useTaskListData = () => {
 
   const token = localStorage.getItem("token");
 
-  const loadTasks = useCallback(async () => {
+  const reloadTasks = useCallback(async () => {
     if (!token) return;
 
     try {
-      const me = await getMe();
-      setUser(me);
-
       const tasks = await fetchTasks();
       setTasks(tasks);
     } catch (err) {
@@ -45,9 +42,34 @@ export const useTaskListData = () => {
     }
   }, [navigate, resolveError, token]);
 
+  const loadInitialData = useCallback(async () => {
+    if (!token) return;
+
+    try {
+      const me = await getMe();
+      setUser(me);
+
+      await reloadTasks();
+    } catch (err) {
+      const result = resolveError(err);
+
+      switch (result.type) {
+        case "redirect":
+          navigate(result.to);
+          break;
+        case "message":
+          console.error(result.message);
+          break;
+        case "validation":
+          console.error(result.message);
+          break;
+      }
+    }
+  }, [navigate, reloadTasks, resolveError, token]);
+
   useEffect(() => {
-    void Promise.resolve().then(loadTasks);
-  }, [loadTasks]);
+    void Promise.resolve().then(loadInitialData);
+  }, [loadInitialData]);
 
   const clearUser = () => {
     setUser(null);
@@ -56,7 +78,7 @@ export const useTaskListData = () => {
   const toggleCompletion = async (task: Task) => {
     try {
       await toggleTaskComplete(task.id, task.completed);
-      await loadTasks();
+      await reloadTasks();
     } catch (err) {
       const result = resolveError(err);
 
@@ -77,7 +99,7 @@ export const useTaskListData = () => {
   const removeTask = async (task: Task) => {
     try {
       await deleteTask(task.id);
-      await loadTasks();
+      await reloadTasks();
     } catch (err) {
       const result = resolveError(err);
 
@@ -98,7 +120,7 @@ export const useTaskListData = () => {
   return {
     user,
     tasks,
-    loadTasks,
+    reloadTasks,
     clearUser,
     toggleCompletion,
     removeTask,


### PR DESCRIPTION
## ■ 目的

useTaskListData 内の初期取得処理とタスク再取得処理を分離し、タスク操作後に不要な `getMe()` が再実行される状態を整理する。

Closes #96

---

## ■ 変更内容

- `loadTasks` を `loadInitialData` と `reloadTasks` に分離
- 初期表示時は `loadInitialData` から `getMe()` と `reloadTasks()` を実行
- タスク操作後の完了切替・削除では `reloadTasks()` のみ実行
- `TaskAdd` / `EditTaskModal` に渡す再取得関数を `reloadTasks` に変更

---

## ■ 影響範囲

- 今日のタスク一覧の初期表示
- タスク追加後の一覧再取得
- タスク編集後の一覧再取得
- タスク完了切替後の一覧再取得
- タスク削除後の一覧再取得

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [ ] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build`
  - `tsc -b && vite build` 成功
- `git diff --check`
  - 問題なし
- Edge ゲストモード + CDP で確認
  - 初期表示でユーザー名と今日のタスクが表示されることを確認
  - タスク追加後: `POST /tasks 201` → `GET /tasks 200`
  - タスク編集後: `PATCH /tasks/:id 200` → `GET /tasks 200`
  - 完了切替後: `PATCH /tasks/:id 200` → `GET /tasks 200`
  - タスク削除後: `DELETE /tasks/:id 200` → `GET /tasks 200`
  - 上記タスク操作後に `GET /me` が再実行されないことを確認
  - 画面リロード後、ユーザー名と今日のタスクが再表示されることを確認
  - リロード後の初期取得として `GET /me 200` と `GET /tasks 200` が実行されることを確認
  - `console.error` / `console.warn` / runtime exception: 0 件

開発環境では初期表示およびリロード時に `GET /me` / `GET /tasks` が2回ずつ記録されるが、React 開発環境の再実行によるものと判断。タスク操作後は `GET /tasks` のみで、今回の分離目的を満たしている。

エラーケースは今回エラー処理分岐を変更していないため未確認。

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Medium
* 理由: UI変更はなく差分は限定的だが、初期取得とタスク操作後のAPI呼び出し回数を意図的に変更しているため。初期表示・各タスク操作・画面リロードで既存表示と再取得挙動を確認済み。

---

## ■ 懸念点・補足

- UI変更・対象外ファイル変更・エラー処理分岐変更が混ざっていないことを確認済み。