### PR TITLE
useTaskListData の alert 表示を TaskList 側へ移す

### DIFF
--- a/frontend/src/features/tasks/components/TaskList.tsx
+++ b/frontend/src/features/tasks/components/TaskList.tsx
@@ -6,14 +6,16 @@ import { TaskAdd } from "./TaskAdd";
 import EditTaskModal from "./EditTaskModal"
 import { TaskListHeader } from "./TaskListHeader";
 import { TaskListItem } from "./TaskListItem";
-import { Navigate } from "react-router-dom"
+import { Navigate, useNavigate } from "react-router-dom"
 import { filterTodayTasks } from "../utils/taskFilters";
 import { useTaskListData } from "../hooks/useTaskListData";
+import type { ApiErrorResult } from "../../../hooks/useApiError";
 
 // 今日のタスク一覧
 export const TaskList = () => {
   const [isOpen, setIsOpen] = useState(false)
   const [selectedTask, setSelectedTask] = useState<Task | null>(null)
+  const navigate = useNavigate();
   const {
     user,
     tasks,
@@ -25,12 +27,38 @@ export const TaskList = () => {
 
   const token = localStorage.getItem("token");
 
+  const handleTaskActionError = (error: ApiErrorResult) => {
+    switch (error.type) {
+      case "redirect":
+        navigate(error.to);
+        break;
+      case "validation":
+        alert(error.message);
+        break;
+      case "message":
+        alert(error.message);
+        break;
+    }
+  };
+
+  const handleToggle = async (task: Task) => {
+    const result = await toggleCompletion(task);
+
+    if (!result.ok) {
+      handleTaskActionError(result.error);
+    }
+  };
+
   const handleDelete = async (task: Task) => {
     const confirmed = window.confirm("このタスクを削除しますか？");
 
     if (!confirmed) return;
 
-    await removeTask(task);
+    const result = await removeTask(task);
+
+    if (!result.ok) {
+      handleTaskActionError(result.error);
+    }
   }
 
   const todayTasks = filterTodayTasks(tasks);
@@ -60,7 +88,7 @@ export const TaskList = () => {
             <TaskListItem
               key={task.id}
               task={task}
-              onToggle={toggleCompletion}
+              onToggle={handleToggle}
               onEdit={openModal}
               onDelete={handleDelete}
             />

--- a/frontend/src/features/tasks/hooks/useTaskListData.ts
+++ b/frontend/src/features/tasks/hooks/useTaskListData.ts
@@ -4,12 +4,17 @@ import { getMe } from "../../auth/api/authApi";
 import { deleteTask, fetchTasks, toggleTaskComplete } from "../api/tasksApi";
 import type { Task } from "../types/task";
 import { useApiError } from "../../../hooks/useApiError";
+import type { ApiErrorResult } from "../../../hooks/useApiError";
 
 type User = {
   id: number;
   name: string;
   email: string;
 };
+
+type TaskActionResult =
+  | { ok: true }
+  | { ok: false; error: ApiErrorResult };
 
 export const useTaskListData = () => {
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -75,45 +80,27 @@ export const useTaskListData = () => {
     setUser(null);
   };
 
-  const toggleCompletion = async (task: Task) => {
+  const toggleCompletion = async (task: Task): Promise<TaskActionResult> => {
     try {
       await toggleTaskComplete(task.id, task.completed);
       await reloadTasks();
+      return { ok: true };
     } catch (err) {
       const result = resolveError(err);
 
-      switch (result.type) {
-        case "redirect":
-          navigate(result.to);
-          break;
-        case "validation":
-          alert(result.message);
-          break;
-        case "message":
-          alert(result.message);
-          break;
-      }
+      return { ok: false, error: result };
     }
   };
 
-  const removeTask = async (task: Task) => {
+  const removeTask = async (task: Task): Promise<TaskActionResult> => {
     try {
       await deleteTask(task.id);
       await reloadTasks();
+      return { ok: true };
     } catch (err) {
       const result = resolveError(err);
 
-      switch (result.type) {
-        case "redirect":
-          navigate(result.to);
-          break;
-        case "validation":
-          alert(result.message);
-          break;
-        case "message":
-          alert(result.message);
-          break;
-      }
+      return { ok: false, error: result };
     }
   }
 


### PR DESCRIPTION
## ■ 目的

useTaskListData 内に含まれている alert によるエラー表示処理を TaskList 側へ移し、hook から UI 表示責務を排除する。

Closes #98

---

## ■ 変更内容

- `toggleCompletion` / `removeTask` が成功・失敗の結果を返すように変更
- `useTaskListData` 内のタスク操作エラー時の `alert` 表示を削除
- `TaskList` 側でタスク操作結果を受け取り、失敗時に `alert(error.message)` を表示
- `redirect` エラー時は `TaskList` 側で `navigate(error.to)` するように変更

---

## ■ 影響範囲

- 今日のタスク一覧
- タスク完了切替
- タスク削除
- タスク操作エラー時の表示処理

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build`
  - `tsc -b && vite build` 成功
- `git diff --check`
  - 問題なし
- Edge ゲストモード + CDP で確認
  - 初期表示でユーザー名と対象タスクが表示されることを確認
  - 完了切替成功: `PATCH /tasks/:id 200` → `GET /tasks 200`
  - 削除成功: confirm 表示 → `DELETE /tasks/:id 200` → `GET /tasks 200`
  - 完了切替エラー: `TaskList` 側で `alert(error.message)` が表示されることを確認
  - 削除エラー: `TaskList` 側で `alert(error.message)` が表示されることを確認
  - `console.error` / `console.warn` / runtime exception: 0 件

エラーケースはページ内で `window.fetch` と `window.alert` を一時的に差し替え、`VALIDATION_ERROR` の `details[].message` が既存どおり `error.message` として alert 表示されることを確認。

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: API呼び出し内容・回数・UI文言は変更せず、タスク操作エラー時の表示責務を hook から TaskList へ移しただけのため。成功系とエラー系の表示を確認済み。

---

## ■ 懸念点・補足

- なし