### PR TITLE
エラー表示のinline styleをCSSへ移行

### DIFF
--- a/frontend/src/components/common.css
+++ b/frontend/src/components/common.css
@@ -10,3 +10,13 @@ button {
   cursor: pointer;
 }
 
+.error-list {
+  color: #d33;
+  margin: 8px 0;
+  padding-left: 20px;
+}
+
+.error-message {
+  color: #d33;
+  margin: 8px 0;
+}

--- a/frontend/src/features/auth/components/Login.tsx
+++ b/frontend/src/features/auth/components/Login.tsx
@@ -68,14 +68,14 @@ export const Login = () => {
       <FormField label="パスワード" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
 
       {fieldErrors.length > 0 && (
-        <ul style={{ color: "#d33", margin: "8px 0", paddingLeft: "20px" }}>
+        <ul className="error-list">
           {fieldErrors.map((message, index) => (
             <li key={`${message}-${index}`}>{message}</li>
           ))}
         </ul>
       )}
 
-      {error && <p style={{ color: "#d33", margin: "8px 0" }}>{error}</p>}
+      {error && <p className="error-message">{error}</p>}
 
       <button className="auth-button" onClick={handleLogin} disabled={loading}>
         {loading ? "ログイン中..." : "ログイン"}

--- a/frontend/src/features/auth/components/Register.tsx
+++ b/frontend/src/features/auth/components/Register.tsx
@@ -1,3 +1,4 @@
+import "../../../components/common.css"
 import { useState } from "react"
 import { createUser } from "../api/authApi"
 import { useNavigate, Link } from "react-router-dom"
@@ -74,14 +75,14 @@ export const Register = () => {
       <FormField label="パスワード" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
 
       {fieldErrors.length > 0 && (
-        <ul style={{ color: "#d33", margin: "8px 0", paddingLeft: "20px" }}>
+        <ul className="error-list">
           {fieldErrors.map((message, index) => (
             <li key={`${message}-${index}`}>{message}</li>
           ))}
         </ul>
       )}
 
-      {error && <p style={{ color: "#d33", margin: "8px 0" }}>{error}</p>}
+      {error && <p className="error-message">{error}</p>}
 
       <button className="auth-button" onClick={handleRegister}>
         登録

--- a/frontend/src/features/tasks/components/EditTaskModal.tsx
+++ b/frontend/src/features/tasks/components/EditTaskModal.tsx
@@ -143,14 +143,14 @@ function EditTaskModalContent({
         </div>
 
         {fieldErrors.length > 0 && (
-          <ul style={{ color: "#d33", margin: "8px 0", paddingLeft: "20px" }}>
+          <ul className="error-list">
             {fieldErrors.map((message, index) => (
               <li key={`${message}-${index}`}>{message}</li>
             ))}
           </ul>
         )}
 
-        {error && <p style={{ color: "#d33", margin: "8px 0" }}>{error}</p>}
+        {error && <p className="error-message">{error}</p>}
 
         <div className="modal-actions">
           <button className="cancel" onClick={onClose}>

--- a/frontend/src/features/tasks/components/TaskAdd.tsx
+++ b/frontend/src/features/tasks/components/TaskAdd.tsx
@@ -86,14 +86,14 @@ export const TaskAdd = ({ onTaskAdded }: Props) => {
       </button>
 
       {fieldErrors.length > 0 && (
-        <ul style={{ color: "#d33", margin: "8px 0", paddingLeft: "20px" }}>
+        <ul className="error-list">
           {fieldErrors.map((message, index) => (
             <li key={`${message}-${index}`}>{message}</li>
           ))}
         </ul>
       )}
 
-      {error && <p style={{ color: "#d33", margin: "8px 0" }}>{error}</p>}
+      {error && <p className="error-message">{error}</p>}
     </div>
   );
 };


### PR DESCRIPTION
## ■ 目的

エラー表示に使われている inline style をCSSクラスへ移し、表示スタイルの責務をコンポーネント内から分離する。

Closes #103

---

## ■ 変更内容

- `common.css` にエラー表示用の共通クラスを追加
  - `.error-list`
  - `.error-message`
- 以下のコンポーネントでエラー表示の inline style を `className` に置き換え
  - `Login.tsx`
  - `Register.tsx`
  - `TaskAdd.tsx`
  - `EditTaskModal.tsx`
- `Register.tsx` で共通CSSを参照するため `common.css` import を追加

---

## ■ 影響範囲

- ログイン画面のエラー表示
- ユーザー登録画面のエラー表示
- タスク追加フォームのエラー表示
- タスク編集モーダルのエラー表示

エラー処理ロジック、表示条件、文言、バリデーション仕様は変更していない。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build`
  - OK
- `git diff --check`
  - OK
- ブラウザ確認
  - 登録画面: 空送信時のエラー表示が `.error-list` で表示され、既存と同じ `#d33`, `margin: 8px 0`, `padding-left: 20px` であることを確認
  - ログイン画面: 空送信時のエラー表示が `.error-list` で表示され、既存と同じ `#d33`, `margin: 8px 0`, `padding-left: 20px` であることを確認
  - タスク追加: 未入力追加時のエラー表示が `.error-list` で表示され、既存と同じ `#d33`, `margin: 8px 0`, `padding-left: 20px` であることを確認

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: inline styleを同等のCSSクラスへ移しただけで、表示条件・文言・エラー制御ロジックには触れていないため。

---

## ■ 懸念点・補足

- `TaskAdd.tsx` の見出しに残っている inline style はエラー表示ではないため、本Issueの対象外として変更していない。
- タスク編集モーダルのエラー表示は、作業前の画面操作で再現できなかったため、コード上の置き換えとビルド確認までとしている。