### PR TITLE
tasks配下の汎用CSSクラス名の衝突を回避

### DIFF
--- a/frontend/src/features/auth/components/FormField.css
+++ b/frontend/src/features/auth/components/FormField.css
@@ -1,6 +1,8 @@
 .form-group {
   display: flex;
   flex-direction: column;
+  margin-bottom: 16px;
+  text-align: left;
 }
 
 .form-label {

--- a/frontend/src/features/tasks/components/EditTaskModal.css
+++ b/frontend/src/features/tasks/components/EditTaskModal.css
@@ -25,23 +25,27 @@
   margin-bottom: 20px;
 }
 
-.form-group {
+.edit-task-modal-form-group {
   display: flex;
   flex-direction: column;
   margin-bottom: 16px;
   text-align: left;
 }
 
-.form-group label {
+.edit-task-modal-form-group label {
   margin-bottom: 6px;
 }
 
-.input {
+.edit-task-modal-input {
+  width: 100%;
   background: #2a2a2a;
   border: 1px solid #444;
   border-radius: 6px;
   padding: 8px;
+  box-sizing: border-box;
   color: #fff;
+  font-size: 18px;
+  margin-bottom: 12px;
 }
 
 .checkbox-group {
@@ -78,4 +82,3 @@
   padding: 8px 12px;
   border-radius: 6px;
 }
-

--- a/frontend/src/features/tasks/components/EditTaskModal.tsx
+++ b/frontend/src/features/tasks/components/EditTaskModal.tsx
@@ -111,19 +111,19 @@ function EditTaskModalContent({
       <div className="modal" onClick={(e) => e.stopPropagation()}>
         <h2 className="modal-title">タスク編集</h2>
 
-        <div className="form-group">
+        <div className="edit-task-modal-form-group">
           <label>タイトル</label>
           <input
-            className="input"
+            className="edit-task-modal-input"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
           />
         </div>
 
-        <div className="form-group">
+        <div className="edit-task-modal-form-group">
           <label>期限</label>
           <input
-            className="input"
+            className="edit-task-modal-input"
             type="date"
             value={dueDate ?? ""}
             onChange={(e) => setDueDate(e.target.value || null)}

--- a/frontend/src/features/tasks/components/TaskAdd.tsx
+++ b/frontend/src/features/tasks/components/TaskAdd.tsx
@@ -68,14 +68,14 @@ export const TaskAdd = ({ onTaskAdded }: Props) => {
       <h3 style={{marginTop: 0}}>タスク追加</h3>
 
       <input
-        className="input"
+        className="task-input"
         placeholder="タスク名を入力してください"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
       />
 
       <input
-        className="input"
+        className="task-input"
         type="date"
         value={dueDate}
         onChange={(e) => setDueDate(e.target.value)}

--- a/frontend/src/features/tasks/components/TaskList.css
+++ b/frontend/src/features/tasks/components/TaskList.css
@@ -82,14 +82,15 @@
   margin-bottom: 12px;
 }
 
-.input {
+.task-input {
   width: 100%;
-  padding: 10px;
+  padding: 8px;
   margin-bottom: 12px;
   box-sizing: border-box;
-  background-color: #1f2937;
-  color: #e5e7eb;
-  border: 1px solid #374151;
+  background-color: #2a2a2a;
+  color: #fff;
+  border: 1px solid #444;
+  border-radius: 6px;
   font-size: 18px;
 }
 
@@ -132,4 +133,3 @@
   margin-top: 8px;
   color: #f1f1f1;
 }
-


### PR DESCRIPTION
## ■ 目的

tasks配下で使用している汎用的なCSSクラス名をtasks固有の名前へ変更し、他featureや他コンポーネントとの意図しないスタイル衝突を防ぐ。

Closes #105

---

## ■ 変更内容

- `TaskAdd.tsx` の `.input` を `.task-input` に変更
- `EditTaskModal.tsx` の `.form-group` を `.edit-task-modal-form-group` に変更
- `EditTaskModal.tsx` の `.input` を `.edit-task-modal-input` に変更
- 対応するCSSセレクタを更新
- 旧 `.input` / `.form-group` のグローバルな重なりで成立していた既存表示を、新しいクラス側に明示
- auth側フォーム表示維持のため、`FormField.css` に不足していた既存相当の `margin-bottom` / `text-align` を明示

---

## ■ 影響範囲

- タスク追加フォームの入力欄
- タスク編集モーダルのフォーム行・入力欄
- ログイン画面 / ユーザー登録画面のフォーム行表示

ロジック、フォーム入力処理、API通信、エラー処理は変更していない。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build`
  - OK
- `git diff --check`
  - OK
- 作業前にタスク追加フォーム・タスク編集モーダルのcomputed styleを確認
- 作業後に以下が作業前と同等であることを確認
  - タスク追加フォーム入力欄の幅、padding、margin、背景色、文字色、border、border-radius、font-size
  - タスク編集モーダル入力欄の幅、padding、margin、背景色、文字色、border、border-radius、font-size
  - タスク編集モーダルのフォーム行の `text-align: left` / `margin-bottom: 16px`
- tasks対象内に旧 `.input` / `.form-group` が残っていないことを確認
- ログイン画面 / ユーザー登録画面のフォーム名が左寄せ、フォーム間余白が `16px` に戻っていることを確認

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: CSSクラス名変更と同等スタイルの移し替えのみで、コンポーネントのロジックや挙動には触れていないため。

---

## ■ 懸念点・補足

- Issue本文ではauth側CSSは対象外だったが、tasks側の `.form-group` 衝突を解消したことで、作業前にauth側へ偶然効いていた `text-align: left` / `margin-bottom: 16px` が外れることを確認した。
- 既存UI維持のため、auth側の本来の責務である `FormField.css` に同等スタイルを最小限で明示している。
- 共通化やCSS設計変更は行っていない。