### PR TITLE
common.cssの責務とグローバル影響範囲を整理

### DIFF
--- a/frontend/src/components/common.css
+++ b/frontend/src/components/common.css
@@ -1,3 +1,4 @@
+/* Global element styles shared by auth and tasks screens. */
 h2, h3 {
   color: #f3f4f6;
 }
@@ -10,6 +11,7 @@ button {
   cursor: pointer;
 }
 
+/* Shared error display styles used by form-level validation messages. */
 .error-list {
   color: #d33;
   margin: 8px 0;


### PR DESCRIPTION
## ■ 目的

`common.css` の責務を明記し、グローバル要素指定と共通エラー表示クラスの影響範囲を読み取りやすくする。

Closes #107

---

## ■ 変更内容

- `common.css` に責務コメントを追加
  - `h2, h3` / `body` / `button` は auth / tasks 画面で共有されるグローバル要素スタイルとして明記
  - `.error-list` / `.error-message` はフォームレベルのvalidation message用共通スタイルとして明記

---

## ■ 影響範囲

- `frontend/src/components/common.css`

CSS定義値は変更していないため、UI表示・ロジック・挙動への影響はなし。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build`
  - OK
- `git diff --check`
  - OK
- ログイン、登録、タスク一覧、タスク追加、タスク編集モーダルの主要表示値を確認済み
- 最終差分はコメント2行のみ

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: CSSの値やセレクタ構造は変更せず、責務コメントのみを追加しているため。

---

## ■ 懸念点・補足

- `common.css` のグローバル要素指定の移動・削除は影響が広いため、本PRでは実施していない。
- 次Issue候補として、グローバル要素指定をどこへ置くかの方針決め、または `common.css` import位置の整理が考えられる。