### PR TITLE
common.cssのグローバル要素指定をindex.cssへ移動

### DIFF
--- a/frontend/src/components/common.css
+++ b/frontend/src/components/common.css
@@ -1,16 +1,3 @@
-/* Global element styles shared by auth and tasks screens. */
-h2, h3 {
-  color: #f3f4f6;
-}
-
-body {
-  color: #e5e7eb;
-}
-
-button {
-  cursor: pointer;
-}
-
 /* Shared error display styles used by form-level validation messages. */
 .error-list {
   color: #d33;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -63,7 +63,12 @@
 }
 
 body {
+  color: #e5e7eb;
   margin: 0;
+}
+
+button {
+  cursor: pointer;
 }
 
 h1,
@@ -83,6 +88,7 @@ h1 {
   }
 }
 h2 {
+  color: #f3f4f6;
   font-size: 24px;
   line-height: 118%;
   letter-spacing: -0.24px;
@@ -90,6 +96,9 @@ h2 {
   @media (max-width: 1024px) {
     font-size: 20px;
   }
+}
+h3 {
+  color: #f3f4f6;
 }
 p {
   margin: 0;


### PR DESCRIPTION
## ■ 目的

`common.css` に定義されているグローバル要素指定を `index.css` へ移動し、アプリ全体に適用されるスタイルの責務を明確化する。

Closes #109

---

## ■ 変更内容

- `common.css` から以下のグローバル要素指定を削除
  - `body`
  - `button`
  - `h2, h3`
- `index.css` に同等のスタイルを移動
  - `body { color: #e5e7eb; }`
  - `button { cursor: pointer; }`
  - `h2 { color: #f3f4f6; }`
  - `h3 { color: #f3f4f6; }`
- `.error-list` / `.error-message` は `common.css` に残した

---

## ■ 影響範囲

- アプリ全体のグローバル要素スタイル
- ログイン画面
- ユーザー登録画面
- タスク一覧画面
- タスク追加フォーム
- タスク編集モーダル

スタイル値は変更せず、定義場所のみを整理している。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build`
  - OK
- `git diff --check`
  - OK
- 作業前後で以下の主要表示値が同等であることを確認
  - `body` の文字色
  - `h2` / `h3` の文字色
  - `button` の cursor
  - ログイン / 登録 / タスク一覧 / タスク追加 / タスク編集モーダルの主要表示
- Commander側でも画面確認済み

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: グローバル要素指定の定義場所のみを移動し、スタイル値・ロジック・コンポーネント構造は変更していないため。

---

## ■ 懸念点・補足

- `index.css` には既に `h2` 定義があるため、既存表示維持のため `h2 { color: #f3f4f6; }` を同セレクタに明示している。
- `.error-list` / `.error-message` はIssue対象外のため `common.css` に残している。