### PR TITLE
auth配下CSSの責務を整理

### DIFF
--- a/frontend/src/features/auth/components/FormField.css
+++ b/frontend/src/features/auth/components/FormField.css
@@ -1,16 +1,16 @@
-.form-group {
+.auth-form-group {
   display: flex;
   flex-direction: column;
   margin-bottom: 16px;
   text-align: left;
 }
 
-.form-label {
+.auth-form-label {
   margin-bottom: 6px;
   font-size: 14px;
 }
 
-.form-input {
+.auth-form-input {
   /* width: 100%; */
   padding: 10px;
   background: #2a2a2a;

--- a/frontend/src/features/auth/components/FormField.tsx
+++ b/frontend/src/features/auth/components/FormField.tsx
@@ -14,10 +14,10 @@ export const FormField = ({
   onChange
 }: Props) => {
   return (
-    <div className="form-group">
-      <label className="form-label">{label}</label>
+    <div className="auth-form-group">
+      <label className="auth-form-label">{label}</label>
       <input
-        className="form-input"
+        className="auth-form-input"
         type={type}
         value={value}
         onChange={onChange}


### PR DESCRIPTION
## ■ 目的

auth配下のCSS責務を整理し、認証フォームのスタイルがauth配下で完結して読み取れる状態にする。

Closes #113

---

## ■ 変更内容

- `FormField` の汎用的なクラス名をauth用のクラス名へ変更
  - `.form-group` → `.auth-form-group`
  - `.form-label` → `.auth-form-label`
  - `.form-input` → `.auth-form-input`
- `FormField.css` の対応セレクタ名を更新

CSS値、ロジック、コンポーネント構造は変更していない。

---

## ■ 影響範囲

- ログイン画面のフォーム表示
- ユーザー登録画面のフォーム表示
- `FormField.tsx`
- `FormField.css`

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build`
  - OK
- `git diff --check`
  - OK
- 作業前後でログイン画面・登録画面のフォーム行、ラベル、入力欄、ボタンの表示値が同等であることを確認
- 画面上に旧 `.form-group` / `.form-label` / `.form-input` が残っていないことを確認
- Commander側でも画面確認済み

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: auth配下のFormFieldクラス名とCSSセレクタ名を対応して変更しただけで、CSS値やロジックには触れていないため。

---

## ■ 懸念点・補足

- `AuthCard.css` は既に `auth-` prefixで責務が明確なため、今回は変更していない。
- tasks配下、common.css、index.css、App.cssには触れていない。