### PR TITLE
CSS小掃除候補を整理

### DIFF
--- a/frontend/src/features/auth/components/FormField.css
+++ b/frontend/src/features/auth/components/FormField.css
@@ -20,7 +20,7 @@
   font-size: 18px;
 }
 
-input:focus {
+.auth-form-input:focus {
   outline: none;
   border: 1px solid #b1b1b1;
 }

--- a/frontend/src/features/tasks/components/EditTaskModal.css
+++ b/frontend/src/features/tasks/components/EditTaskModal.css
@@ -32,7 +32,7 @@
   text-align: left;
 }
 
-.edit-task-modal-form-group label {
+.edit-task-modal-label {
   margin-bottom: 6px;
 }
 

--- a/frontend/src/features/tasks/components/EditTaskModal.tsx
+++ b/frontend/src/features/tasks/components/EditTaskModal.tsx
@@ -112,7 +112,7 @@ function EditTaskModalContent({
         <h2 className="modal-title">タスク編集</h2>
 
         <div className="edit-task-modal-form-group">
-          <label>タイトル</label>
+          <label className="edit-task-modal-label">タイトル</label>
           <input
             className="edit-task-modal-input"
             value={title}
@@ -121,7 +121,7 @@ function EditTaskModalContent({
         </div>
 
         <div className="edit-task-modal-form-group">
-          <label>期限</label>
+          <label className="edit-task-modal-label">期限</label>
           <input
             className="edit-task-modal-input"
             type="date"

--- a/frontend/src/features/tasks/components/TaskAdd.tsx
+++ b/frontend/src/features/tasks/components/TaskAdd.tsx
@@ -65,7 +65,7 @@ export const TaskAdd = ({ onTaskAdded }: Props) => {
 
   return (
     <div className="task-add">
-      <h3 style={{marginTop: 0}}>タスク追加</h3>
+      <h3 className="task-add-title">タスク追加</h3>
 
       <input
         className="task-input"

--- a/frontend/src/features/tasks/components/TaskList.css
+++ b/frontend/src/features/tasks/components/TaskList.css
@@ -49,7 +49,7 @@
   text-align: left;
 }
 
-.task-left input {
+.task-checkbox {
   transform: translateY(1px);
 }
 
@@ -78,7 +78,8 @@
   border-radius: 8px;
 }
 
-.task-add h3 {
+.task-add-title {
+  margin-top: 0;
   margin-bottom: 12px;
 }
 
@@ -109,7 +110,7 @@
   margin-bottom: 16px;
 }
 
-.header h1 {
+.task-list-title {
   font-size: 24px;
   font-weight: bold;
   margin: 0;

--- a/frontend/src/features/tasks/components/TaskListHeader.tsx
+++ b/frontend/src/features/tasks/components/TaskListHeader.tsx
@@ -18,7 +18,7 @@ export const TaskListHeader = ({
   return (
     <div className="header">
       <div className="header-top">
-        <h1>今日のタスク</h1>
+        <h1 className="task-list-title">今日のタスク</h1>
         <button
           className="button-with-icon logout"
           onClick={onLogout}

--- a/frontend/src/features/tasks/components/TaskListItem.tsx
+++ b/frontend/src/features/tasks/components/TaskListItem.tsx
@@ -18,6 +18,7 @@ export const TaskListItem = ({
     <div className="task-row">
       <div className="task-left">
         <input
+          className="task-checkbox"
           type="checkbox"
           checked={task.completed}
           onChange={() => onToggle(task)}


### PR DESCRIPTION
## ■ 目的

CSS整理STEP4の横断確認で見つかった小掃除候補を整理し、CSSセレクタの責務をより明確にする。

Closes #117

---

## ■ 変更内容

- `FormField.css` のfocus指定をauth入力欄に限定
  - `input:focus` → `.auth-form-input:focus`
- `TaskAdd` の見出しinline styleをCSSへ移行
  - `style={{marginTop: 0}}` → `.task-add-title`
- tasks CSSの子要素セレクタを明示クラスへ置き換え
  - `.task-left input` → `.task-checkbox`
  - `.header h1` → `.task-list-title`
  - `.task-add h3` → `.task-add-title`
  - `.edit-task-modal-form-group label` → `.edit-task-modal-label`

CSS値、ロジック、UIデザインは変更していない。

---

## ■ 影響範囲

- ログイン / 登録画面のauth input focus表示
- タスク追加フォーム見出し
- タスク一覧チェックボックス
- タスク一覧タイトル
- タスク編集モーダルのラベル

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run build`
  - OK
- `git diff --check`
  - OK
- 作業前後で以下の表示値が同等であることを確認
  - auth input focus
  - タスク追加見出し
  - タスク一覧チェックボックス
  - タスク一覧タイトル
  - タスク編集モーダルラベル
- 旧子要素セレクタに依存した対象が画面上に残っていないことを確認
- Commander側でも画面確認済み

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: CSS値は変えず、既存表示を保ったままセレクタ対象を明示クラスへ置き換えているため。

---

## ■ 懸念点・補足

- 共通化は行っていない。
- auth/tasksの境界を崩さない範囲で、既存セレクタの明示性だけを上げている。