### PR TITLE
feature間依存ルールを明文化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,17 @@ Current phase:
 * Shared code must stay in common directories
 * Do not move files across layers unless instructed
 
+### Frontend Feature Dependency Rules
+
+* Feature public entry points must be `frontend/src/features/{feature}/index.ts`
+* Code outside a feature should import that feature through `features/{feature}`
+* Code outside a feature should not import directly from that feature's internal directories such as `components`, `hooks`, `api`, or `types`
+* Code inside the same feature may use relative imports to its own internal directories
+* Cross-feature dependencies should be kept minimal and explicit
+* Dependencies on `auth` from business features such as `tasks` are allowed when using authentication as shared application infrastructure
+* Reverse dependencies from `auth` to business features such as `tasks` are prohibited
+* Do not expose additional feature internals from `index.ts` unless the task explicitly requires it
+
 ---
 
 ## ■ Core Principles


### PR DESCRIPTION
## ■ 目的

feature間の依存ルールを明文化し、今後のリファクタリングや機能追加時に依存関係が逆流しないようにする。

Closes #124

---

## ■ 変更内容

- `AGENTS.md` に `Frontend Feature Dependency Rules` を追加
- feature公開口を `frontend/src/features/{feature}/index.ts` とする方針を明記
- feature外からは `features/{feature}` 経由でimportする方針を明記
- feature内部ディレクトリへの直接importを避ける方針を明記
- 同一feature内の相対importは許容することを明記
- `tasks → auth` のような認証基盤への依存は許容することを明記
- `auth → tasks` のような業務featureへの逆依存は禁止することを明記

実装ファイル、ロジック、UI、挙動は変更していない。

---

## ■ 影響範囲

- Codex作業時のfrontend feature依存ルール
- 今後のfeature公開口・import経路整理の判断基準

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `git diff --check`
  - OK
- 差分確認
  - `AGENTS.md` のみ変更
  - 実装ファイルの変更なし
- ドキュメントのみの変更のため、ビルド・ブラウザ確認は未実施

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: `AGENTS.md` へのルール追記のみで、実装・ロジック・UI・挙動に影響しないため。

---

## ■ 懸念点・補足

- `refactoring_plan.md` はリポジトリ外でCommander管理の資料として扱い、今回の変更対象外。
- 既存の `tasks → auth` 依存は、認証基盤への依存として許容する前提で明文化している。
- 既存importの修正や依存解消は今回の対象外。