### PR TITLE
TypeScriptコードのセミコロン方針を統一

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,9 +1,9 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import { defineConfig, globalIgnores } from 'eslint/config'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+import { defineConfig, globalIgnores } from 'eslint/config';
 
 export default defineConfig([
   globalIgnores(['dist']),
@@ -19,5 +19,8 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      semi: ['error', 'always'],
+    },
   },
-])
+]);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
-import "./App.css"
-import { Routes, Route, Navigate } from "react-router-dom"
-import { Login, Register } from "./features/auth"
-import { TaskList } from "./features/tasks"
+import "./App.css";
+import { Routes, Route, Navigate } from "react-router-dom";
+import { Login, Register } from "./features/auth";
+import { TaskList } from "./features/tasks";
 
 
 export const App = () => {
@@ -16,5 +16,5 @@ export const App = () => {
         </Routes>
       </div>
     </div>
-  )
-}
+  );
+};

--- a/frontend/src/features/auth/api/authApi.ts
+++ b/frontend/src/features/auth/api/authApi.ts
@@ -48,4 +48,4 @@ export const getMe = async () => {
   });
 
   return json.data.user;
-}
+};

--- a/frontend/src/features/auth/components/AuthCard.tsx
+++ b/frontend/src/features/auth/components/AuthCard.tsx
@@ -1,10 +1,10 @@
-import "./AuthCard.css"
+import "./AuthCard.css";
 
 type Props = {
-  title: string
-  children: React.ReactNode
-  footer: React.ReactNode
-}
+  title: string;
+  children: React.ReactNode;
+  footer: React.ReactNode;
+};
 
 export const AuthCard = ({ title, children, footer }: Props) => {
   return (
@@ -23,5 +23,5 @@ export const AuthCard = ({ title, children, footer }: Props) => {
         </div>
       </div>
     </div>
-  )
-}
+  );
+};

--- a/frontend/src/features/auth/components/FormField.tsx
+++ b/frontend/src/features/auth/components/FormField.tsx
@@ -1,11 +1,11 @@
-import "./FormField.css"
+import "./FormField.css";
 
 type Props = {
-  label: string
-  type?: string
-  value: string
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
-}
+  label: string;
+  type?: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+};
 
 export const FormField = ({
   label,
@@ -23,5 +23,5 @@ export const FormField = ({
         onChange={onChange}
       />
     </div>
-  )
-}
+  );
+};

--- a/frontend/src/features/auth/components/Login.tsx
+++ b/frontend/src/features/auth/components/Login.tsx
@@ -1,7 +1,7 @@
-import "../../../components/common.css"
+import "../../../components/common.css";
 import { useState } from "react";
 import { useApiError } from "../../../hooks/useApiError";
-import { Link, useNavigate } from "react-router-dom"
+import { Link, useNavigate } from "react-router-dom";
 import { AuthCard } from "./AuthCard";
 import { FormField } from "./FormField";
 import { login } from "../api/authApi";
@@ -12,7 +12,7 @@ export const Login = () => {
   const [error, setError] = useState("");
   const [fieldErrors, setFieldErrors] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
-  const navigate = useNavigate()
+  const navigate = useNavigate();
   const { resolveError } = useApiError();
 
   const handleLogin = async () => {
@@ -24,7 +24,7 @@ export const Login = () => {
       const data = await login(email, password);
 
       localStorage.setItem("token", data.token);
-      navigate("/tasks")
+      navigate("/tasks");
 
     } catch(err) {
       const result = resolveError(err);
@@ -82,4 +82,4 @@ export const Login = () => {
       </button>
     </AuthCard>
   );
-}
+};

--- a/frontend/src/features/auth/components/Register.tsx
+++ b/frontend/src/features/auth/components/Register.tsx
@@ -1,34 +1,34 @@
-import "../../../components/common.css"
-import { useState } from "react"
-import { createUser } from "../api/authApi"
-import { useNavigate, Link } from "react-router-dom"
+import "../../../components/common.css";
+import { useState } from "react";
+import { createUser } from "../api/authApi";
+import { useNavigate, Link } from "react-router-dom";
 import { AuthCard } from "./AuthCard";
 import { FormField } from "./FormField";
 import { useApiError } from "../../../hooks/useApiError";
 
 export const Register = () => {
-  const [name, setName] = useState("")
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [fieldErrors, setFieldErrors] = useState<string[]>([]);
   const { resolveError } = useApiError();
   const navigate = useNavigate();
 
   const handleRegister = async (e: React.FormEvent) => {
-    e.preventDefault()
+    e.preventDefault();
     setError("");
     setFieldErrors([]);
 
     // フロントバリデーション（最低限）
-    const newErrors: Record<string, string> = {}
-    if (!name) newErrors.name = "ユーザー名は必須です"
-    if (!email) newErrors.email = "メールアドレスは必須です"
-    if (!password) newErrors.password = "パスワードは必須です"
+    const newErrors: Record<string, string> = {};
+    if (!name) newErrors.name = "ユーザー名は必須です";
+    if (!email) newErrors.email = "メールアドレスは必須です";
+    if (!password) newErrors.password = "パスワードは必須です";
 
     if (Object.keys(newErrors).length > 0) {
       setFieldErrors(Object.values(newErrors));
-      return
+      return;
     }
 
     try {
@@ -58,7 +58,7 @@ export const Register = () => {
           break;
       }
     }
-  }
+  };
 
   return (
     <AuthCard
@@ -88,5 +88,5 @@ export const Register = () => {
         登録
       </button>
     </AuthCard>
-  )
-}
+  );
+};

--- a/frontend/src/features/tasks/api/tasksApi.ts
+++ b/frontend/src/features/tasks/api/tasksApi.ts
@@ -33,7 +33,7 @@ export const createTask = async (
   });
 
   return json.data.task;
-}
+};
 
 // PATCH /tasks/:id (完了チェック)
 export const toggleTaskComplete = async (
@@ -52,7 +52,7 @@ export const toggleTaskComplete = async (
   });
 
   return json.data.task;
-}
+};
 
 // PATCH /tasks/:id (タスク編集)
 export const updateTask = async (
@@ -72,7 +72,7 @@ export const updateTask = async (
   });
 
   return json.data.task;
-}
+};
 
 // DELETE /tasks/:id
 export const deleteTask = async (id: number) => {
@@ -82,4 +82,4 @@ export const deleteTask = async (id: number) => {
   });
 
   return json;
-}
+};

--- a/frontend/src/features/tasks/components/EditTaskModal.tsx
+++ b/frontend/src/features/tasks/components/EditTaskModal.tsx
@@ -1,23 +1,23 @@
-import "../../../components/common.css"
-import "./EditTaskModal.css"
-import { useEffect, useState } from "react"
-import { updateTask } from "../api/tasksApi"
-import type { Task } from "../types/task"
+import "../../../components/common.css";
+import "./EditTaskModal.css";
+import { useEffect, useState } from "react";
+import { updateTask } from "../api/tasksApi";
+import type { Task } from "../types/task";
 import { useApiError } from "../../../hooks/useApiError";
 import { useNavigate } from "react-router-dom";
 
 type Props = {
-  isOpen: boolean
-  onClose: () => void
-  task: Task | null
-  onUpdated: () => void
-}
+  isOpen: boolean;
+  onClose: () => void;
+  task: Task | null;
+  onUpdated: () => void;
+};
 
 type ModalContentProps = {
-  onClose: () => void
-  task: Task
-  onUpdated: () => void
-}
+  onClose: () => void;
+  task: Task;
+  onUpdated: () => void;
+};
 
 export function EditTaskModal({
   isOpen,
@@ -28,7 +28,7 @@ export function EditTaskModal({
   useEffect(() => {
     const handleEsc = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
-    }
+    };
 
     if (isOpen) {
       window.addEventListener("keydown", handleEsc);
@@ -36,10 +36,10 @@ export function EditTaskModal({
 
     return () => {
       window.removeEventListener("keydown", handleEsc);
-    }
-  }, [isOpen, onClose])
+    };
+  }, [isOpen, onClose]);
 
-  if (!isOpen || !task) return null
+  if (!isOpen || !task) return null;
 
   return (
     <EditTaskModalContent
@@ -48,7 +48,7 @@ export function EditTaskModal({
       task={task}
       onUpdated={onUpdated}
     />
-  )
+  );
 }
 
 function EditTaskModalContent({
@@ -73,7 +73,7 @@ function EditTaskModalContent({
       title,
       dueDate: dueDate === "" ? null : dueDate,
       completed,
-    }
+    };
 
     try {
       await updateTask(payload);
@@ -104,7 +104,7 @@ function EditTaskModalContent({
           break;
       }
     }
-  }
+  };
 
   return (
     <div className="modal-overlay" onClick={onClose}>
@@ -162,5 +162,5 @@ function EditTaskModalContent({
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/features/tasks/components/TaskAdd.tsx
+++ b/frontend/src/features/tasks/components/TaskAdd.tsx
@@ -1,5 +1,5 @@
-import "../../../components/common.css"
-import "./TaskList.css"
+import "../../../components/common.css";
+import "./TaskList.css";
 import { useState } from "react";
 import { createTask } from "../api/tasksApi";
 import { useApiError } from "../../../hooks/useApiError";
@@ -24,7 +24,7 @@ export const TaskAdd = ({ onTaskAdded }: Props) => {
 
     if (!title.trim()) {
       setFieldErrors(["タスク名を入力してください"]);
-      return
+      return;
     }
 
     // タスク追加API

--- a/frontend/src/features/tasks/components/TaskList.tsx
+++ b/frontend/src/features/tasks/components/TaskList.tsx
@@ -1,19 +1,19 @@
-import "./TaskList.css"
+import "./TaskList.css";
 import { useState } from "react";
 import type { Task } from "../types/task";
 import { TaskAdd } from "./TaskAdd";
-import { EditTaskModal } from "./EditTaskModal"
+import { EditTaskModal } from "./EditTaskModal";
 import { TaskListHeader } from "./TaskListHeader";
 import { TaskListItem } from "./TaskListItem";
-import { Navigate, useNavigate } from "react-router-dom"
+import { Navigate, useNavigate } from "react-router-dom";
 import { filterTodayTasks } from "../utils/taskFilters";
 import { useTaskListData } from "../hooks/useTaskListData";
 import type { ApiErrorResult } from "../../../hooks/useApiError";
 
 // 今日のタスク一覧
 export const TaskList = () => {
-  const [isOpen, setIsOpen] = useState(false)
-  const [selectedTask, setSelectedTask] = useState<Task | null>(null)
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const navigate = useNavigate();
   const {
     user,
@@ -58,20 +58,20 @@ export const TaskList = () => {
     if (!result.ok) {
       handleTaskActionError(result.error);
     }
-  }
+  };
 
   const todayTasks = filterTodayTasks(tasks);
 
   const openModal = (task: Task) => {
-    setSelectedTask(task)
-    setIsOpen(true)
-  }
+    setSelectedTask(task);
+    setIsOpen(true);
+  };
 
   const handleLogout = () => {
     localStorage.removeItem("token");
     clearUser();
     window.location.href = "/login";
-  }
+  };
 
   if (!token) {
     return <Navigate to="/login" />;

--- a/frontend/src/features/tasks/hooks/useTaskListData.ts
+++ b/frontend/src/features/tasks/hooks/useTaskListData.ts
@@ -13,8 +13,8 @@ type User = {
 };
 
 type TaskActionResult =
-  | { ok: true }
-  | { ok: false; error: ApiErrorResult };
+  | { ok: true; }
+  | { ok: false; error: ApiErrorResult; };
 
 export const useTaskListData = () => {
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -102,7 +102,7 @@ export const useTaskListData = () => {
 
       return { ok: false, error: result };
     }
-  }
+  };
 
   return {
     user,

--- a/frontend/src/hooks/useApiError.ts
+++ b/frontend/src/hooks/useApiError.ts
@@ -7,9 +7,9 @@ import { ApiError } from "../lib/errors";
 import type { ValidationDetail } from "../lib/errors";
 
 export type ApiErrorResult =
-  | { type: "redirect"; to: string }
-  | { type: "validation"; details: ValidationDetail[]; message: string }
-  | { type: "message"; message: string };
+  | { type: "redirect"; to: string; }
+  | { type: "validation"; details: ValidationDetail[]; message: string; }
+  | { type: "message"; message: string; };
 
 const resolveMessage = (error: ApiError) => {
   return ERROR_MESSAGES[error.code] ?? error.message ?? GENERIC_ERROR_MESSAGE;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,8 +1,8 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import { App } from './App'
-import { BrowserRouter } from "react-router-dom"
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import { App } from './App';
+import { BrowserRouter } from "react-router-dom";
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -10,4 +10,4 @@ createRoot(document.getElementById('root')!).render(
       <App />
     </BrowserRouter>
   </StrictMode>,
-)
+);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
@@ -16,4 +16,4 @@ export default defineConfig({
       usePolling: true
     }
   }
-})
+});


### PR DESCRIPTION
## ■ 目的

TypeScript / React コードのセミコロン使用方針を「常に付ける」に統一し、コードスタイルの一貫性を向上させる。

Closes #131

---

## ■ 変更内容

- `frontend/src` 配下の TypeScript / TSX コードにセミコロンを追加
- 型定義のメンバー区切りもセミコロンありに統一
- `frontend/vite.config.ts` も設定ファイルとしてセミコロンありに統一
- `frontend/eslint.config.js` に `semi: ['error', 'always']` を追加し、今後の文末セミコロン漏れを lint で検知できるように変更

---

## ■ 影響範囲

- フロントエンドの TypeScript / React コードスタイル
- ESLint による文末セミコロンチェック
- ロジック、UI、import 経路、挙動は変更なし

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `npm run lint`: OK
- `npm run build`: OK
- `git diff --check`: OK

※ コードスタイル統一のみのため、ブラウザ操作確認は前回の既存挙動確認結果を前提とし、今回は lint / build による確認を実施。

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: セミコロン追加と ESLint ルール追加のみで、実行ロジックや UI 表示には影響しないため。

---

## ■ 懸念点・補足

- ESLint の `semi` ルールは主に文末セミコロンを検知する目的で追加。
- TypeScript の inline object 型におけるプロパティ区切りも、今回の方針に合わせて手動でセミコロンありに統一。