### PR TITLE
POST /users validationをcontroller側へ整理する

### DIFF
--- a/backend/controller/user_controller.go
+++ b/backend/controller/user_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"net/http"
 	"net/mail"
+	"unicode/utf8"
 
 	"github.com/msubaru14/my-app-backend/dto"
 	"github.com/msubaru14/my-app-backend/model"
@@ -84,7 +85,7 @@ func (uc *UserController) CreateUser(c *gin.Context) {
 			Code:    apperror.DetailRequired,
 			Message: "パスワードは必須です",
 		})
-	} else if len(input.Password) < 6 {
+	} else if utf8.RuneCountInString(input.Password) < 6 {
 		details = append(details, apperror.ErrorDetail{
 			Field:   "password",
 			Code:    apperror.DetailTooShort,

--- a/backend/controller/user_controller.go
+++ b/backend/controller/user_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"net/http"
+	"net/mail"
 
 	"github.com/msubaru14/my-app-backend/dto"
 	"github.com/msubaru14/my-app-backend/model"
@@ -69,6 +70,12 @@ func (uc *UserController) CreateUser(c *gin.Context) {
 			Code:    apperror.DetailRequired,
 			Message: "メールアドレスは必須です",
 		})
+	} else if !isValidEmail(input.Email) {
+		details = append(details, apperror.ErrorDetail{
+			Field:   "email",
+			Code:    apperror.DetailInvalidFormat,
+			Message: "メールアドレスの形式が不正です",
+		})
 	}
 
 	if input.Password == "" {
@@ -76,6 +83,12 @@ func (uc *UserController) CreateUser(c *gin.Context) {
 			Field:   "password",
 			Code:    apperror.DetailRequired,
 			Message: "パスワードは必須です",
+		})
+	} else if len(input.Password) < 6 {
+		details = append(details, apperror.ErrorDetail{
+			Field:   "password",
+			Code:    apperror.DetailTooShort,
+			Message: "パスワードは6文字以上で入力してください",
 		})
 	}
 
@@ -145,4 +158,9 @@ func (uc *UserController) GetMe(c *gin.Context) {
 	response.Success(c, gin.H{
 		"user": res,
 	})
+}
+
+func isValidEmail(email string) bool {
+	address, err := mail.ParseAddress(email)
+	return err == nil && address.Address == email
 }

--- a/backend/dto/user_dto.go
+++ b/backend/dto/user_dto.go
@@ -1,9 +1,9 @@
 package dto
 
 type CreateUserInput struct {
-	Name     string `json:"name" binding:"required"`
-	Email    string `json:"email" binding:"required,email"`
-	Password string `json:"password" binding:"required,min=6"`
+	Name     string `json:"name"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
 }
 
 type UserResponse struct {


### PR DESCRIPTION
## ■ 目的

`POST /users` の validation を controller 側へ寄せ、API仕様書に合わせて入力不正時に `VALIDATION_ERROR + details` を返すようにする。

Issue #142 の当初方針では既存挙動維持としていたが、DTO `binding` tag によりAPI仕様書上の validation response と実挙動が不整合になっていたため、「API仕様への整合」を目的に含める。

Closes #142

---

## ■ 変更内容

- `CreateUserInput` から DTO `binding` tag を削除
- `ShouldBindJSON` をJSON形式不正の検出に限定
- `POST /users` controller側で以下のvalidationを実施
  - `name` 未入力: `REQUIRED`
  - `email` 未入力: `REQUIRED`
  - `email` 形式不正: `INVALID_FORMAT`
  - `password` 未入力: `REQUIRED`
  - `password` 6文字未満: `TOO_SHORT`
- JSON形式不正は従来どおり `INVALID_REQUEST` を返す

---

## ■ 影響範囲

- Backend: `POST /users` のvalidation response
- Frontend: ユーザー登録画面で `VALIDATION_ERROR + details` を受け取る挙動

login / task / auth周辺 / DBスキーマは対象外。

---

## ■ 動作確認

* [ ] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [ ] コンソールエラーがない
* [x] エラーケースを確認した

※ このPRは `POST /users` validation response の意図的な挙動変更を含むため、「既存挙動が変わっていない」は未チェック。
※ API直接確認のため、ブラウザコンソール確認は未実施。

---

## ■ 確認ログ（任意）

`go test ./...`

```txt
?   	github.com/msubaru14/my-app-backend	[no test files]
?   	github.com/msubaru14/my-app-backend/controller	[no test files]
?   	github.com/msubaru14/my-app-backend/db	[no test files]
?   	github.com/msubaru14/my-app-backend/dto	[no test files]
?   	github.com/msubaru14/my-app-backend/middleware	[no test files]
?   	github.com/msubaru14/my-app-backend/model	[no test files]
?   	github.com/msubaru14/my-app-backend/pkg/apperror	[no test files]
?   	github.com/msubaru14/my-app-backend/pkg/response	[no test files]
?   	github.com/msubaru14/my-app-backend/repository	[no test files]
?   	github.com/msubaru14/my-app-backend/router	[no test files]
?   	github.com/msubaru14/my-app-backend/service	[no test files]
?   	github.com/msubaru14/my-app-backend/utils	[no test files]
```

API確認結果:

| ケース | 結果 |
| --- | --- |
| name 未入力 | `400 VALIDATION_ERROR`, `details[0].field=name`, `REQUIRED` |
| email 未入力 | `400 VALIDATION_ERROR`, `details[0].field=email`, `REQUIRED` |
| email 形式不正 | `400 VALIDATION_ERROR`, `details[0].field=email`, `INVALID_FORMAT` |
| password 未入力 | `400 VALIDATION_ERROR`, `details[0].field=password`, `REQUIRED` |
| password 6文字未満 | `400 VALIDATION_ERROR`, `details[0].field=password`, `TOO_SHORT` |
| 正常登録 | `201 Created` |
| JSON形式不正 | `400 INVALID_REQUEST` |
| name重複 / email別 | `201 Created` |
| email重複 / name別 | `500 INTERNAL_SERVER_ERROR`（既存挙動維持、別Issue #143） |

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Medium
* 理由: `POST /users` のvalidation responseを `INVALID_REQUEST` から `VALIDATION_ERROR + details` へ意図的に変更するため、フロントエンドのエラー表示に影響する可能性がある。

---

## ■ 懸念点・補足

- email形式チェックにはGo標準の `net/mail.ParseAddress` を使用。
- email重複時に `500 INTERNAL_SERVER_ERROR` が返る問題は今回のscope外とし、別Issue #143 として起票済み。