### PR TITLE
backend task作成 validation の責務整理

### DIFF
--- a/backend/controller/task_controller.go
+++ b/backend/controller/task_controller.go
@@ -29,41 +29,9 @@ func (tc *TaskController) CreateTask(c *gin.Context) {
 		return
 	}
 
-	if input.Title == "" {
-		response.Error(c, http.StatusBadRequest, apperror.APIError{
-			Code:    apperror.CodeValidationError,
-			Message: "validation error",
-			Details: []apperror.ErrorDetail{
-				{
-					Field:   "title",
-					Code:    apperror.DetailRequired,
-					Message: "タイトルは必須です",
-				},
-			},
-		})
+	if apiErr := validateCreateTaskInput(&input); apiErr != nil {
+		response.Error(c, http.StatusBadRequest, *apiErr)
 		return
-	}
-
-	// フォーマット簡易チェック（YYYY-MM-DD）
-	if input.DueDate != nil {
-		if *input.DueDate == "" {
-			input.DueDate = nil
-		} else {
-			if _, err := time.Parse("2006-01-02", *input.DueDate); err != nil {
-				response.Error(c, http.StatusBadRequest, apperror.APIError{
-					Code:    apperror.CodeValidationError,
-					Message: "validation error",
-					Details: []apperror.ErrorDetail{
-						{
-							Field:   "dueDate",
-							Code:    apperror.DetailInvalidFormat,
-							Message: "日付は YYYY-MM-DD 形式で入力してください",
-						},
-					},
-				})
-				return
-			}
-		}
 	}
 
 	userID := c.GetUint("user_id")
@@ -93,6 +61,63 @@ func (tc *TaskController) CreateTask(c *gin.Context) {
 	response.SuccessCreated(c, gin.H{
 		"task": res,
 	})
+}
+
+func validateCreateTaskInput(input *dto.CreateTaskInput) *apperror.APIError {
+	if err := validateTitle(input.Title); err != nil {
+		return err
+	}
+
+	if err := validateCreateDueDate(input); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateTitle(title string) *apperror.APIError {
+	if title != "" {
+		return nil
+	}
+
+	return &apperror.APIError{
+		Code:    apperror.CodeValidationError,
+		Message: "validation error",
+		Details: []apperror.ErrorDetail{
+			{
+				Field:   "title",
+				Code:    apperror.DetailRequired,
+				Message: "タイトルは必須です",
+			},
+		},
+	}
+}
+
+func validateCreateDueDate(input *dto.CreateTaskInput) *apperror.APIError {
+	if input.DueDate == nil {
+		return nil
+	}
+
+	if *input.DueDate == "" {
+		input.DueDate = nil
+		return nil
+	}
+
+	if _, err := time.Parse("2006-01-02", *input.DueDate); err != nil {
+		return &apperror.APIError{
+			Code:    apperror.CodeValidationError,
+			Message: "validation error",
+			Details: []apperror.ErrorDetail{
+				{
+					Field:   "dueDate",
+					Code:    apperror.DetailInvalidFormat,
+					Message: "日付は YYYY-MM-DD 形式で入力してください",
+				},
+			},
+		}
+	}
+
+	return nil
 }
 
 // GET /tasks


### PR DESCRIPTION
## ■ 目的

`POST /tasks` の validation を、既存API仕様・挙動を維持したまま controller 側で整理する。

Closes #145

---

## ■ 変更内容

- `CreateTask` 内の title 必須チェックを `validateTitle` に分離
- `CreateTask` 内の dueDate 作成時 validation を `validateCreateDueDate` に分離
- `validateCreateTaskInput` から task 作成 validation 全体の流れを確認できる形に整理
- `dueDate` 未指定 / `null` / 空文字許容、不正形式エラー、正常形式作成の既存挙動を維持

---

## ■ 影響範囲

- Backend `POST /tasks` の controller 内 validation
- `backend/controller/task_controller.go`

対象外:
- `PATCH /tasks/:id` validation
- dueDate create/update 差分の仕様変更
- error handling 全体整理
- DTO / service / repository / auth / DB 変更
- UI変更

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `gofmt -w backend/controller/task_controller.go`
- `git diff --check`
- `go test ./...`
- `docker compose logs --tail 20 backend`

`POST /tasks` 確認ケース:

| ケース | 結果 |
| --- | --- |
| title 未入力 `{}` | 400 / `VALIDATION_ERROR` / `title REQUIRED` |
| title 空文字 | 400 / `VALIDATION_ERROR` / `title REQUIRED` |
| dueDate 未指定 | 201 / `dueDate: null` |
| dueDate null | 201 / `dueDate: null` |
| dueDate 空文字 | 201 / `dueDate: null` |
| dueDate 不正形式 | 400 / `VALIDATION_ERROR` / `dueDate INVALID_FORMAT` |
| dueDate 正常形式 | 201 / 指定日付で作成 |
| 正常作成 | 201 / `completed: false`, `dueDate: null` |

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: 変更範囲は `POST /tasks` の controller 内 validation 整理に限定し、APIレスポンス形式・error code・dueDate の既存挙動は動作確認で維持を確認済み。

---

## ■ 懸念点・補足

- `PATCH /tasks/:id` の dueDate 仕様差分は既存どおり維持し、このPRでは扱わない。
- backend API確認のためブラウザコンソール確認は対象外。代わりに backend log を確認し、今回のAPI確認に伴うエラー出力がないことを確認。