### PR TITLE
backend user登録 password 最小長 validation 定数化

### DIFF
--- a/backend/controller/user_controller.go
+++ b/backend/controller/user_controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 	"net/mail"
 	"unicode/utf8"
@@ -9,6 +10,7 @@ import (
 	"github.com/msubaru14/my-app-backend/model"
 	"github.com/msubaru14/my-app-backend/pkg/apperror"
 	"github.com/msubaru14/my-app-backend/pkg/response"
+	"github.com/msubaru14/my-app-backend/pkg/validation"
 	"github.com/msubaru14/my-app-backend/service"
 
 	"github.com/gin-gonic/gin"
@@ -85,11 +87,11 @@ func (uc *UserController) CreateUser(c *gin.Context) {
 			Code:    apperror.DetailRequired,
 			Message: "パスワードは必須です",
 		})
-	} else if utf8.RuneCountInString(input.Password) < 6 {
+	} else if utf8.RuneCountInString(input.Password) < validation.UserPasswordMinLength {
 		details = append(details, apperror.ErrorDetail{
 			Field:   "password",
 			Code:    apperror.DetailTooShort,
-			Message: "パスワードは6文字以上で入力してください",
+			Message: fmt.Sprintf("パスワードは%d文字以上で入力してください", validation.UserPasswordMinLength),
 		})
 	}
 

--- a/backend/pkg/validation/constants.go
+++ b/backend/pkg/validation/constants.go
@@ -1,3 +1,6 @@
 package validation
 
-const TaskTitleMaxLength = 100
+const (
+	TaskTitleMaxLength    = 100
+	UserPasswordMinLength = 6
+)


### PR DESCRIPTION
## ■ 目的

`POST /users` の password 最小長 validation で使っている数値制約を、既存挙動を変更せずに定数化する。

Closes #149

---

## ■ 変更内容

- `validation.UserPasswordMinLength = 6` を追加
- `user_controller.go` の password 最小長チェックを定数参照へ変更
- password 最小長エラーメッセージを定数値から組み立てる形に変更
- 既存の error code / details / message は維持

---

## ■ 影響範囲

- Backend `POST /users` の password 最小長 validation
- `backend/controller/user_controller.go`
- `backend/pkg/validation/constants.go`

対象外:
- password 最小長の値変更
- password validation 仕様変更
- user登録 validation 全体整理
- task validation の変更
- error handling 全体整理
- auth / DB / UI 変更

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `gofmt -w backend/controller/user_controller.go backend/pkg/validation/constants.go`
- `git diff --check`
- `go test ./...`

API確認:

| ケース | 結果 |
| --- | --- |
| `POST /users` password 5文字 | 400 / `VALIDATION_ERROR` / `password TOO_SHORT` / `パスワードは6文字以上で入力してください` |
| `POST /users` password 6文字 | 201 |

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: password 最小長の値とAPIレスポンスは変更せず、直書きされていた数値を名前付き定数へ置き換えるだけの変更。

---

## ■ 懸念点・補足

- このPRは #150 の `backend/pkg/validation` 追加を前提にした stacked PR。#150 merge 後に必要であれば base branch を `main` へ変更する。