### PR TITLE
backend task更新 validation の責務整理

### DIFF
--- a/backend/controller/task_controller.go
+++ b/backend/controller/task_controller.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -190,6 +191,11 @@ func (tc *TaskController) UpdateTask(c *gin.Context) {
 		return
 	}
 
+	if apiErr := validateUpdateTaskInput(&input); apiErr != nil {
+		response.Error(c, http.StatusBadRequest, *apiErr)
+		return
+	}
+
 	task, err := tc.Service.UpdateTask(uint(id), userID, input)
 	if err != nil {
 		if apiErr, ok := err.(*apperror.APIError); ok {
@@ -215,6 +221,87 @@ func (tc *TaskController) UpdateTask(c *gin.Context) {
 	response.Success(c, gin.H{
 		"task": res,
 	})
+}
+
+func validateUpdateTaskInput(input *dto.UpdateTaskRequest) *apperror.APIError {
+	details := []apperror.ErrorDetail{}
+
+	if input.Title != nil {
+		details = append(details, validateUpdateTitle(input)...)
+	}
+
+	if input.DueDate != nil {
+		details = append(details, validateUpdateDueDate(input)...)
+	}
+
+	if len(details) == 0 {
+		return nil
+	}
+
+	return &apperror.APIError{
+		Code:    apperror.CodeValidationError,
+		Message: "validation error",
+		Details: details,
+	}
+}
+
+func validateUpdateTitle(input *dto.UpdateTaskRequest) []apperror.ErrorDetail {
+	trimmed := strings.TrimSpace(*input.Title)
+	input.Title = &trimmed
+
+	return validateUpdateTitleValue(trimmed)
+}
+
+func validateUpdateTitleValue(title string) []apperror.ErrorDetail {
+	if title == "" {
+		return []apperror.ErrorDetail{
+			{
+				Field:   "title",
+				Code:    apperror.DetailRequired,
+				Message: "タイトルは必須です",
+			},
+		}
+	}
+
+	if utf8.RuneCountInString(title) > validation.TaskTitleMaxLength {
+		return []apperror.ErrorDetail{
+			{
+				Field:   "title",
+				Code:    apperror.DetailTooLong,
+				Message: fmt.Sprintf("タイトルは%d文字以内で入力してください", validation.TaskTitleMaxLength),
+			},
+		}
+	}
+
+	return nil
+}
+
+func validateUpdateDueDate(input *dto.UpdateTaskRequest) []apperror.ErrorDetail {
+	trimmed := strings.TrimSpace(*input.DueDate)
+
+	if trimmed == "" {
+		return []apperror.ErrorDetail{
+			{
+				Field:   "dueDate",
+				Code:    apperror.DetailInvalidFormat,
+				Message: "日付は空文字不可です",
+			},
+		}
+	}
+
+	if _, err := time.Parse("2006-01-02", trimmed); err != nil {
+		return []apperror.ErrorDetail{
+			{
+				Field:   "dueDate",
+				Code:    apperror.DetailInvalidFormat,
+				Message: "日付は YYYY-MM-DD 形式で入力してください",
+			},
+		}
+	}
+
+	input.DueDate = &trimmed
+
+	return nil
 }
 
 // DELETE /tasks/:id

--- a/backend/service/task_service.go
+++ b/backend/service/task_service.go
@@ -2,15 +2,10 @@ package service
 
 import (
 	"errors"
-	"fmt"
-	"strings"
-	"time"
-	"unicode/utf8"
 
 	"github.com/msubaru14/my-app-backend/dto"
 	"github.com/msubaru14/my-app-backend/model"
 	"github.com/msubaru14/my-app-backend/pkg/apperror"
-	"github.com/msubaru14/my-app-backend/pkg/validation"
 	"github.com/msubaru14/my-app-backend/repository"
 	"gorm.io/gorm"
 )
@@ -31,59 +26,8 @@ func (s *TaskService) GetTasksByUser(userID uint) ([]model.Task, error) {
 
 // タスク更新
 func (s *TaskService) UpdateTask(id uint, userID uint, req dto.UpdateTaskRequest) (*model.Task, error) {
-	if req.Title == nil && req.DueDate == nil && req.Completed == nil {
+	if !hasUpdateTaskFields(req) {
 		return nil, apperror.NewInvalidRequest("no fields to update")
-	}
-
-	details := []apperror.ErrorDetail{}
-
-	// タイトルバリデーション
-	if req.Title != nil {
-		trimmed := strings.TrimSpace(*req.Title)
-		if trimmed == "" {
-			details = append(details, apperror.ErrorDetail{
-				Field:   "title",
-				Code:    apperror.DetailRequired,
-				Message: "タイトルは必須です",
-			})
-		}
-
-		if utf8.RuneCountInString(trimmed) > validation.TaskTitleMaxLength {
-			details = append(details, apperror.ErrorDetail{
-				Field:   "title",
-				Code:    apperror.DetailTooLong,
-				Message: fmt.Sprintf("タイトルは%d文字以内で入力してください", validation.TaskTitleMaxLength),
-			})
-		}
-
-		req.Title = &trimmed
-	}
-
-	// 日付バリデーション
-	if req.DueDate != nil {
-		trimmed := strings.TrimSpace(*req.DueDate)
-
-		if trimmed == "" {
-			details = append(details, apperror.ErrorDetail{
-				Field:   "dueDate",
-				Code:    apperror.DetailInvalidFormat,
-				Message: "日付は空文字不可です",
-			})
-		} else {
-			if _, err := time.Parse("2006-01-02", trimmed); err != nil {
-				details = append(details, apperror.ErrorDetail{
-					Field:   "dueDate",
-					Code:    apperror.DetailInvalidFormat,
-					Message: "日付は YYYY-MM-DD 形式で入力してください",
-				})
-			} else {
-				req.DueDate = &trimmed
-			}
-		}
-	}
-
-	if len(details) > 0 {
-		return nil, apperror.NewValidationError("validation error", details)
 	}
 
 	// 対象タスク取得
@@ -113,6 +57,10 @@ func (s *TaskService) UpdateTask(id uint, userID uint, req dto.UpdateTaskRequest
 	}
 
 	return task, nil
+}
+
+func hasUpdateTaskFields(req dto.UpdateTaskRequest) bool {
+	return req.Title != nil || req.DueDate != nil || req.Completed != nil
 }
 
 // タスク削除


### PR DESCRIPTION
## ■ 目的

`PATCH /tasks/:id` の validation を、既存API仕様・挙動を維持したまま整理し、request validation と業務ルールの責務を分かりやすくする。

Closes #147

---

## ■ 変更内容

- `PATCH /tasks/:id` の title / dueDate request validation を controller 側へ移動
- title / dueDate の trim 補正を controller 側の validation で実施
- service 側は更新フィールド未指定チェック、対象task取得、所有者込み not found 判定、更新適用に整理
- `no fields to update` / validation details / not found の既存レスポンス形式を維持

---

## ■ 影響範囲

- Backend `PATCH /tasks/:id` の validation 処理
- `backend/controller/task_controller.go`
- `backend/service/task_service.go`

対象外:
- task作成 validation の整理
- dueDate create/update 差分の仕様変更
- error handling 全体整理
- APIレスポンス形式変更
- DTO構造の大幅変更
- auth / DB / UI 変更

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `gofmt -w backend/controller/task_controller.go backend/service/task_service.go`
- `git diff --check`
- `go test ./...`

`PATCH /tasks/:id` 確認ケース:

| ケース | 結果 |
| --- | --- |
| 更新フィールド未指定 | 400 / `INVALID_REQUEST` / `no fields to update` |
| title 空文字 | 400 / `VALIDATION_ERROR` / `title REQUIRED` |
| title 空白のみ | 400 / `VALIDATION_ERROR` / `title REQUIRED` |
| title 長すぎ | 400 / `VALIDATION_ERROR` / `title TOO_LONG` |
| dueDate null | 400 / `INVALID_REQUEST` / `no fields to update` |
| dueDate 空文字 | 400 / `VALIDATION_ERROR` / `dueDate INVALID_FORMAT` / `日付は空文字不可です` |
| dueDate 不正形式 | 400 / `VALIDATION_ERROR` / `dueDate INVALID_FORMAT` |
| dueDate 正常形式 | 200 |
| completed のみ更新 | 200 |
| title のみ更新 | 200 |
| dueDate のみ更新 | 200 |
| 存在しない task | 404 / `NOT_FOUND` / `task not found` |
| 他ユーザーの task 更新 | 404 / `NOT_FOUND` / `task not found` |
| title / dueDate 複数validation error | 400 / title と dueDate の `details` が両方返る |

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: request validation の配置を service から controller へ移したが、error code / details / message / HTTP status の既存挙動は確認済み。所有者チェックと not found 判定は service / repository 側に維持している。

---

## ■ 懸念点・補足

- `dueDate: null` は既存どおり未指定扱いとなり、更新フィールド未指定の場合は `INVALID_REQUEST` を返す。
- `POST /tasks` と `PATCH /tasks/:id` の title validation の書き味統一は Issue #152 で別途扱う。