### PR TITLE
backend task title validation の共通化方針整理

### DIFF
--- a/backend/controller/task_controller.go
+++ b/backend/controller/task_controller.go
@@ -29,6 +29,7 @@ func (tc *TaskController) CreateTask(c *gin.Context) {
 		response.Error(c, http.StatusBadRequest, apperror.APIError{
 			Code:    apperror.CodeInvalidRequest,
 			Message: "invalid request",
+			Details: nil,
 		})
 		return
 	}
@@ -68,50 +69,47 @@ func (tc *TaskController) CreateTask(c *gin.Context) {
 }
 
 func validateCreateTaskInput(input *dto.CreateTaskInput) *apperror.APIError {
-	if err := validateTitle(input.Title); err != nil {
-		return err
-	}
+	details := []apperror.ErrorDetail{}
 
-	if err := validateCreateDueDate(input); err != nil {
-		return err
-	}
+	details = append(details, validateTitle(input.Title)...)
+	details = append(details, validateCreateDueDate(input)...)
 
-	return nil
-}
-
-func validateTitle(title string) *apperror.APIError {
-	if title == "" {
-		return &apperror.APIError{
-			Code:    apperror.CodeValidationError,
-			Message: "validation error",
-			Details: []apperror.ErrorDetail{
-				{
-					Field:   "title",
-					Code:    apperror.DetailRequired,
-					Message: "タイトルは必須です",
-				},
-			},
-		}
-	}
-
-	if utf8.RuneCountInString(title) <= validation.TaskTitleMaxLength {
+	if len(details) == 0 {
 		return nil
 	}
 
 	return &apperror.APIError{
 		Code:    apperror.CodeValidationError,
 		Message: "validation error",
-		Details: []apperror.ErrorDetail{
+		Details: details,
+	}
+}
+
+func validateTitle(title string) []apperror.ErrorDetail {
+	if title == "" {
+		return []apperror.ErrorDetail{
+			{
+				Field:   "title",
+				Code:    apperror.DetailRequired,
+				Message: "タイトルは必須です",
+			},
+		}
+	}
+
+	if utf8.RuneCountInString(title) > validation.TaskTitleMaxLength {
+		return []apperror.ErrorDetail{
 			{
 				Field:   "title",
 				Code:    apperror.DetailTooLong,
 				Message: fmt.Sprintf("タイトルは%d文字以内で入力してください", validation.TaskTitleMaxLength),
 			},
-		},
+		}
 	}
+
+	return nil
 }
 
-func validateCreateDueDate(input *dto.CreateTaskInput) *apperror.APIError {
+func validateCreateDueDate(input *dto.CreateTaskInput) []apperror.ErrorDetail {
 	if input.DueDate == nil {
 		return nil
 	}
@@ -122,15 +120,11 @@ func validateCreateDueDate(input *dto.CreateTaskInput) *apperror.APIError {
 	}
 
 	if _, err := time.Parse("2006-01-02", *input.DueDate); err != nil {
-		return &apperror.APIError{
-			Code:    apperror.CodeValidationError,
-			Message: "validation error",
-			Details: []apperror.ErrorDetail{
-				{
-					Field:   "dueDate",
-					Code:    apperror.DetailInvalidFormat,
-					Message: "日付は YYYY-MM-DD 形式で入力してください",
-				},
+		return []apperror.ErrorDetail{
+			{
+				Field:   "dueDate",
+				Code:    apperror.DetailInvalidFormat,
+				Message: "日付は YYYY-MM-DD 形式で入力してください",
 			},
 		}
 	}
@@ -249,31 +243,7 @@ func validateUpdateTitle(input *dto.UpdateTaskRequest) []apperror.ErrorDetail {
 	trimmed := strings.TrimSpace(*input.Title)
 	input.Title = &trimmed
 
-	return validateUpdateTitleValue(trimmed)
-}
-
-func validateUpdateTitleValue(title string) []apperror.ErrorDetail {
-	if title == "" {
-		return []apperror.ErrorDetail{
-			{
-				Field:   "title",
-				Code:    apperror.DetailRequired,
-				Message: "タイトルは必須です",
-			},
-		}
-	}
-
-	if utf8.RuneCountInString(title) > validation.TaskTitleMaxLength {
-		return []apperror.ErrorDetail{
-			{
-				Field:   "title",
-				Code:    apperror.DetailTooLong,
-				Message: fmt.Sprintf("タイトルは%d文字以内で入力してください", validation.TaskTitleMaxLength),
-			},
-		}
-	}
-
-	return nil
+	return validateTitle(trimmed)
 }
 
 func validateUpdateDueDate(input *dto.UpdateTaskRequest) []apperror.ErrorDetail {


### PR DESCRIPTION
## ■ 目的

`POST /tasks` と `PATCH /tasks/:id` の title validation の書き味を揃え、重複している title validation ルールを共通化しやすい形に整理する。

Closes #152

---

## ■ 変更内容

- task title validation を `[]apperror.ErrorDetail` を返す形に整理
- `POST /tasks` と `PATCH /tasks/:id` の title validation で同じ `validateTitle` を使う形に変更
- `POST /tasks` の validation も details を集めて返す形に整理
- `PATCH /tasks/:id` の title trim 補正は既存どおり維持
- `POST /tasks` の title 保存値は既存どおり trim しない
- `POST /tasks` の JSON bind error に `Details: nil` を明示

---

## ■ 影響範囲

- Backend `POST /tasks` の validation detail 返却
- Backend `PATCH /tasks/:id` の title validation 呼び出し
- `backend/controller/task_controller.go`

対象外:
- title 最大長の値変更
- `POST /tasks` title の trim 補正追加
- `PATCH /tasks/:id` title の trim 補正削除
- dueDate validation の仕様変更
- error handling 全体整理
- DTO / service / repository / auth / DB / UI 変更

---

## ■ 動作確認

* [ ] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

※ `POST /tasks` で title と dueDate が同時に不正な場合、複数 `details` を返すようにした。これは validation error details が配列であることに合わせた仕様是正として扱う。

---

## ■ 確認ログ（任意）

- `git diff --check`
- `go test ./...`

API確認:

| ケース | 結果 |
| --- | --- |
| `POST /tasks` title + dueDate 不正 | 400 / `VALIDATION_ERROR` / title と dueDate の `details` が両方返る |
| `POST /tasks` title 長すぎ | 400 / `VALIDATION_ERROR` / `title TOO_LONG` |
| `POST /tasks` dueDate 不正 | 400 / `VALIDATION_ERROR` / `dueDate INVALID_FORMAT` |
| `PATCH /tasks/:id` title + dueDate 不正 | 400 / `VALIDATION_ERROR` / title と dueDate の `details` が両方返る |
| `PATCH /tasks/:id` title 長すぎ | 400 / `VALIDATION_ERROR` / `title TOO_LONG` |

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Medium
* 理由: title validation の共通化自体は小さいが、`POST /tasks` で複数 validation error がある場合に複数 `details` を返す仕様是正を含むため。

---

## ■ 懸念点・補足

- `POST /tasks` は既存どおり title を trim せず保存する。
- `PATCH /tasks/:id` は既存どおり title を trim して更新する。
- `POST /tasks` の複数 details 返却は、既存の単一detail返却から変わる。