### PR TITLE
backend task_controller validation helper 整理

### DIFF
--- a/backend/controller/task_controller.go
+++ b/backend/controller/task_controller.go
@@ -1,19 +1,14 @@
 package controller
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
-	"time"
-	"unicode/utf8"
 
 	"github.com/gin-gonic/gin"
 	"github.com/msubaru14/my-app-backend/dto"
 	"github.com/msubaru14/my-app-backend/model"
 	"github.com/msubaru14/my-app-backend/pkg/apperror"
 	"github.com/msubaru14/my-app-backend/pkg/response"
-	"github.com/msubaru14/my-app-backend/pkg/validation"
 	"github.com/msubaru14/my-app-backend/service"
 )
 
@@ -66,70 +61,6 @@ func (tc *TaskController) CreateTask(c *gin.Context) {
 	response.SuccessCreated(c, gin.H{
 		"task": res,
 	})
-}
-
-func validateCreateTaskInput(input *dto.CreateTaskInput) *apperror.APIError {
-	details := []apperror.ErrorDetail{}
-
-	details = append(details, validateTitle(input.Title)...)
-	details = append(details, validateCreateDueDate(input)...)
-
-	if len(details) == 0 {
-		return nil
-	}
-
-	return &apperror.APIError{
-		Code:    apperror.CodeValidationError,
-		Message: "validation error",
-		Details: details,
-	}
-}
-
-func validateTitle(title string) []apperror.ErrorDetail {
-	if title == "" {
-		return []apperror.ErrorDetail{
-			{
-				Field:   "title",
-				Code:    apperror.DetailRequired,
-				Message: "タイトルは必須です",
-			},
-		}
-	}
-
-	if utf8.RuneCountInString(title) > validation.TaskTitleMaxLength {
-		return []apperror.ErrorDetail{
-			{
-				Field:   "title",
-				Code:    apperror.DetailTooLong,
-				Message: fmt.Sprintf("タイトルは%d文字以内で入力してください", validation.TaskTitleMaxLength),
-			},
-		}
-	}
-
-	return nil
-}
-
-func validateCreateDueDate(input *dto.CreateTaskInput) []apperror.ErrorDetail {
-	if input.DueDate == nil {
-		return nil
-	}
-
-	if *input.DueDate == "" {
-		input.DueDate = nil
-		return nil
-	}
-
-	if _, err := time.Parse("2006-01-02", *input.DueDate); err != nil {
-		return []apperror.ErrorDetail{
-			{
-				Field:   "dueDate",
-				Code:    apperror.DetailInvalidFormat,
-				Message: "日付は YYYY-MM-DD 形式で入力してください",
-			},
-		}
-	}
-
-	return nil
 }
 
 // GET /tasks
@@ -215,63 +146,6 @@ func (tc *TaskController) UpdateTask(c *gin.Context) {
 	response.Success(c, gin.H{
 		"task": res,
 	})
-}
-
-func validateUpdateTaskInput(input *dto.UpdateTaskRequest) *apperror.APIError {
-	details := []apperror.ErrorDetail{}
-
-	if input.Title != nil {
-		details = append(details, validateUpdateTitle(input)...)
-	}
-
-	if input.DueDate != nil {
-		details = append(details, validateUpdateDueDate(input)...)
-	}
-
-	if len(details) == 0 {
-		return nil
-	}
-
-	return &apperror.APIError{
-		Code:    apperror.CodeValidationError,
-		Message: "validation error",
-		Details: details,
-	}
-}
-
-func validateUpdateTitle(input *dto.UpdateTaskRequest) []apperror.ErrorDetail {
-	trimmed := strings.TrimSpace(*input.Title)
-	input.Title = &trimmed
-
-	return validateTitle(trimmed)
-}
-
-func validateUpdateDueDate(input *dto.UpdateTaskRequest) []apperror.ErrorDetail {
-	trimmed := strings.TrimSpace(*input.DueDate)
-
-	if trimmed == "" {
-		return []apperror.ErrorDetail{
-			{
-				Field:   "dueDate",
-				Code:    apperror.DetailInvalidFormat,
-				Message: "日付は空文字不可です",
-			},
-		}
-	}
-
-	if _, err := time.Parse("2006-01-02", trimmed); err != nil {
-		return []apperror.ErrorDetail{
-			{
-				Field:   "dueDate",
-				Code:    apperror.DetailInvalidFormat,
-				Message: "日付は YYYY-MM-DD 形式で入力してください",
-			},
-		}
-	}
-
-	input.DueDate = &trimmed
-
-	return nil
 }
 
 // DELETE /tasks/:id

--- a/backend/controller/task_validation.go
+++ b/backend/controller/task_validation.go
@@ -1,0 +1,133 @@
+package controller
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/msubaru14/my-app-backend/dto"
+	"github.com/msubaru14/my-app-backend/pkg/apperror"
+	"github.com/msubaru14/my-app-backend/pkg/validation"
+)
+
+func validateCreateTaskInput(input *dto.CreateTaskInput) *apperror.APIError {
+	details := []apperror.ErrorDetail{}
+
+	details = append(details, validateTitle(input.Title)...)
+	details = append(details, validateCreateDueDate(input)...)
+
+	if len(details) == 0 {
+		return nil
+	}
+
+	return &apperror.APIError{
+		Code:    apperror.CodeValidationError,
+		Message: "validation error",
+		Details: details,
+	}
+}
+
+func validateCreateDueDate(input *dto.CreateTaskInput) []apperror.ErrorDetail {
+	if input.DueDate == nil {
+		return nil
+	}
+
+	if *input.DueDate == "" {
+		input.DueDate = nil
+		return nil
+	}
+
+	if _, err := time.Parse("2006-01-02", *input.DueDate); err != nil {
+		return []apperror.ErrorDetail{
+			{
+				Field:   "dueDate",
+				Code:    apperror.DetailInvalidFormat,
+				Message: "日付は YYYY-MM-DD 形式で入力してください",
+			},
+		}
+	}
+
+	return nil
+}
+
+func validateUpdateTaskInput(input *dto.UpdateTaskRequest) *apperror.APIError {
+	details := []apperror.ErrorDetail{}
+
+	if input.Title != nil {
+		details = append(details, validateUpdateTitle(input)...)
+	}
+
+	if input.DueDate != nil {
+		details = append(details, validateUpdateDueDate(input)...)
+	}
+
+	if len(details) == 0 {
+		return nil
+	}
+
+	return &apperror.APIError{
+		Code:    apperror.CodeValidationError,
+		Message: "validation error",
+		Details: details,
+	}
+}
+
+func validateUpdateTitle(input *dto.UpdateTaskRequest) []apperror.ErrorDetail {
+	trimmed := strings.TrimSpace(*input.Title)
+	input.Title = &trimmed
+
+	return validateTitle(trimmed)
+}
+
+func validateUpdateDueDate(input *dto.UpdateTaskRequest) []apperror.ErrorDetail {
+	trimmed := strings.TrimSpace(*input.DueDate)
+
+	if trimmed == "" {
+		return []apperror.ErrorDetail{
+			{
+				Field:   "dueDate",
+				Code:    apperror.DetailInvalidFormat,
+				Message: "日付は空文字不可です",
+			},
+		}
+	}
+
+	if _, err := time.Parse("2006-01-02", trimmed); err != nil {
+		return []apperror.ErrorDetail{
+			{
+				Field:   "dueDate",
+				Code:    apperror.DetailInvalidFormat,
+				Message: "日付は YYYY-MM-DD 形式で入力してください",
+			},
+		}
+	}
+
+	input.DueDate = &trimmed
+
+	return nil
+}
+
+func validateTitle(title string) []apperror.ErrorDetail {
+	if title == "" {
+		return []apperror.ErrorDetail{
+			{
+				Field:   "title",
+				Code:    apperror.DetailRequired,
+				Message: "タイトルは必須です",
+			},
+		}
+	}
+
+	if utf8.RuneCountInString(title) > validation.TaskTitleMaxLength {
+		return []apperror.ErrorDetail{
+			{
+				Field:   "title",
+				Code:    apperror.DetailTooLong,
+				Message: fmt.Sprintf("タイトルは%d文字以内で入力してください", validation.TaskTitleMaxLength),
+			},
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## ■ 目的

`task_controller.go` に増えていた task validation helper を controller 本体から分離し、controller の見通しを維持する。

Closes #155

---

## ■ 変更内容

- `backend/controller/task_validation.go` を追加
- `task_controller.go` から task validation helper を移動
- create / update の title / dueDate validation 仕様は維持
- `error.code` / `details[].field` / `details[].code` / `details[].message` は維持

---

## ■ 影響範囲

- Backend task API
  - `POST /tasks`
  - `PATCH /tasks/:id`
- UI変更なし
- service / repository / DTO 変更なし

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [ ] コンソールエラーがない（frontend が起動していなかったため未確認）
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `go test ./...`（backend）成功
- API直叩きで以下を確認
  - `POST /users`: `201`
  - `POST /login`: `200`
  - `POST /tasks` 正常: `201`
  - `POST /tasks` dueDate 空文字: `201`, `dueDate: null`
  - `POST /tasks` title 必須: `400`, `VALIDATION_ERROR`, `REQUIRED`
  - `POST /tasks` dueDate 不正形式: `400`, `VALIDATION_ERROR`, `INVALID_FORMAT`
  - `POST /tasks` title 長すぎ: `400`, `VALIDATION_ERROR`, `TOO_LONG`
  - `PATCH /tasks/:id` 正常: `200`, title trim 維持
  - `PATCH /tasks/:id` dueDate 空文字: `400`, `VALIDATION_ERROR`
  - `PATCH /tasks/:id` dueDate 不正形式: `400`, `VALIDATION_ERROR`
  - `PATCH /tasks/:id` title 長すぎ: `400`, `VALIDATION_ERROR`
  - `PATCH /tasks/:id` title 空白のみ: `400`, `VALIDATION_ERROR`, `REQUIRED`
  - `PATCH /tasks/:id` 更新フィールドなし: `400`, `INVALID_REQUEST`, `no fields to update`
  - `DELETE /tasks/:id`: `200`

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: validation helper の配置整理のみで、既存の validation 仕様・レスポンス形式・service/repository 処理は変更していないため。

---

## ■ 懸念点・補足

- `docs/backend_refactoring_plan.md` の更新は別タスク予定のため、本PRでは変更していない
- frontend が起動していなかったため、ブラウザでの console 確認は未実施
- API確認で使った一時ユーザーと一部タスクがローカル開発DBに残っている可能性あり