### PR TITLE
backend MapErrorCodeToStatus の適用範囲を整理

### DIFF
--- a/backend/controller/auth_controller.go
+++ b/backend/controller/auth_controller.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	"net/http"
-
 	"github.com/msubaru14/my-app-backend/dto"
 	"github.com/msubaru14/my-app-backend/pkg/apperror"
 	"github.com/msubaru14/my-app-backend/pkg/response"
@@ -19,7 +17,7 @@ func (ac *AuthController) Login(c *gin.Context) {
 	var input dto.LoginInput
 
 	if err := c.ShouldBindJSON(&input); err != nil {
-		response.Error(c, http.StatusBadRequest, *apperror.NewInvalidRequest("invalid request"))
+		respondAPIError(c, apperror.NewInvalidRequest("invalid request"))
 		return
 	}
 
@@ -43,14 +41,14 @@ func (ac *AuthController) Login(c *gin.Context) {
 			})
 		}
 
-		response.Error(c, http.StatusBadRequest, *apperror.NewValidationError("validation error", details))
+		respondAPIError(c, apperror.NewValidationError("validation error", details))
 		return
 	}
 
 	// 認証処理
 	token, err := ac.Service.Login(input.Email, input.Password)
 	if err != nil {
-		response.Error(c, http.StatusUnauthorized, *apperror.NewUnauthorized())
+		respondAPIError(c, apperror.NewUnauthorized())
 		return
 	}
 

--- a/backend/controller/error_response.go
+++ b/backend/controller/error_response.go
@@ -1,0 +1,12 @@
+package controller
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/msubaru14/my-app-backend/pkg/apperror"
+	"github.com/msubaru14/my-app-backend/pkg/response"
+)
+
+func respondAPIError(c *gin.Context, apiErr *apperror.APIError) {
+	status := apperror.MapErrorCodeToStatus(apiErr.Code)
+	response.Error(c, status, *apiErr)
+}

--- a/backend/controller/task_controller.go
+++ b/backend/controller/task_controller.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -21,12 +20,12 @@ func (tc *TaskController) CreateTask(c *gin.Context) {
 	var input dto.CreateTaskInput
 
 	if err := c.ShouldBindJSON(&input); err != nil {
-		response.Error(c, http.StatusBadRequest, *apperror.NewInvalidRequest("invalid request"))
+		respondAPIError(c, apperror.NewInvalidRequest("invalid request"))
 		return
 	}
 
 	if apiErr := validateCreateTaskInput(&input); apiErr != nil {
-		response.Error(c, http.StatusBadRequest, *apiErr)
+		respondAPIError(c, apiErr)
 		return
 	}
 
@@ -40,7 +39,7 @@ func (tc *TaskController) CreateTask(c *gin.Context) {
 
 	createdTask, err := tc.Service.CreateTask(task)
 	if err != nil {
-		response.Error(c, http.StatusInternalServerError, *apperror.NewInternalServerError())
+		respondAPIError(c, apperror.NewInternalServerError())
 		return
 	}
 
@@ -61,7 +60,7 @@ func (tc *TaskController) GetTasks(c *gin.Context) {
 	userID := c.GetUint("user_id")
 	tasks, err := tc.Service.GetTasksByUser(userID)
 	if err != nil {
-		response.Error(c, http.StatusInternalServerError, *apperror.NewInternalServerError())
+		respondAPIError(c, apperror.NewInternalServerError())
 		return
 	}
 
@@ -86,7 +85,7 @@ func (tc *TaskController) UpdateTask(c *gin.Context) {
 	idParam := c.Param("id")
 	id, err := strconv.Atoi(idParam)
 	if err != nil {
-		response.Error(c, http.StatusBadRequest, *apperror.NewInvalidRequest("invalid request"))
+		respondAPIError(c, apperror.NewInvalidRequest("invalid request"))
 		return
 	}
 
@@ -94,24 +93,23 @@ func (tc *TaskController) UpdateTask(c *gin.Context) {
 
 	var input dto.UpdateTaskRequest
 	if err := c.ShouldBindJSON(&input); err != nil {
-		response.Error(c, http.StatusBadRequest, *apperror.NewValidationError("validation error", nil))
+		respondAPIError(c, apperror.NewValidationError("validation error", nil))
 		return
 	}
 
 	if apiErr := validateUpdateTaskInput(&input); apiErr != nil {
-		response.Error(c, http.StatusBadRequest, *apiErr)
+		respondAPIError(c, apiErr)
 		return
 	}
 
 	task, err := tc.Service.UpdateTask(uint(id), userID, input)
 	if err != nil {
 		if apiErr, ok := err.(*apperror.APIError); ok {
-			status := apperror.MapErrorCodeToStatus(apiErr.Code)
-			response.Error(c, status, *apiErr)
+			respondAPIError(c, apiErr)
 			return
 		}
 
-		response.Error(c, http.StatusInternalServerError, *apperror.NewInternalServerError())
+		respondAPIError(c, apperror.NewInternalServerError())
 		return
 	}
 
@@ -132,7 +130,7 @@ func (tc *TaskController) DeleteTask(c *gin.Context) {
 	idParam := c.Param("id")
 	id, err := strconv.Atoi(idParam)
 	if err != nil {
-		response.Error(c, http.StatusBadRequest, *apperror.NewInvalidRequest("invalid request"))
+		respondAPIError(c, apperror.NewInvalidRequest("invalid request"))
 		return
 	}
 
@@ -141,12 +139,11 @@ func (tc *TaskController) DeleteTask(c *gin.Context) {
 	err = tc.Service.DeleteTask(uint(id), userID)
 	if err != nil {
 		if apiErr, ok := err.(*apperror.APIError); ok {
-			status := apperror.MapErrorCodeToStatus(apiErr.Code)
-			response.Error(c, status, *apiErr)
+			respondAPIError(c, apiErr)
 			return
 		}
 
-		response.Error(c, http.StatusInternalServerError, *apperror.NewInternalServerError())
+		respondAPIError(c, apperror.NewInternalServerError())
 		return
 	}
 

--- a/backend/controller/user_controller.go
+++ b/backend/controller/user_controller.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"fmt"
-	"net/http"
 	"net/mail"
 	"unicode/utf8"
 
@@ -24,7 +23,7 @@ type UserController struct {
 func (uc *UserController) GetUsers(c *gin.Context) {
 	users, err := uc.Service.GetUsers()
 	if err != nil {
-		response.Error(c, http.StatusInternalServerError, *apperror.NewInternalServerError())
+		respondAPIError(c, apperror.NewInternalServerError())
 		return
 	}
 
@@ -47,7 +46,7 @@ func (uc *UserController) CreateUser(c *gin.Context) {
 	var input dto.CreateUserInput
 
 	if err := c.ShouldBindJSON(&input); err != nil {
-		response.Error(c, http.StatusBadRequest, *apperror.NewInvalidRequest("invalid request"))
+		respondAPIError(c, apperror.NewInvalidRequest("invalid request"))
 		return
 	}
 
@@ -90,7 +89,7 @@ func (uc *UserController) CreateUser(c *gin.Context) {
 	}
 
 	if len(details) > 0 {
-		response.Error(c, http.StatusBadRequest, *apperror.NewValidationError("validation error", details))
+		respondAPIError(c, apperror.NewValidationError("validation error", details))
 		return
 	}
 
@@ -103,7 +102,7 @@ func (uc *UserController) CreateUser(c *gin.Context) {
 
 	createdUser, err := uc.Service.CreateUser(user)
 	if err != nil {
-		response.Error(c, http.StatusInternalServerError, *apperror.NewInternalServerError())
+		respondAPIError(c, apperror.NewInternalServerError())
 		return
 	}
 
@@ -121,19 +120,19 @@ func (uc *UserController) CreateUser(c *gin.Context) {
 func (uc *UserController) GetMe(c *gin.Context) {
 	userIDValue, exists := c.Get("user_id")
 	if !exists {
-		response.Error(c, http.StatusUnauthorized, *apperror.NewUnauthorized())
+		respondAPIError(c, apperror.NewUnauthorized())
 		return
 	}
 
 	userID, ok := userIDValue.(uint)
 	if !ok {
-		response.Error(c, http.StatusUnauthorized, *apperror.NewUnauthorized())
+		respondAPIError(c, apperror.NewUnauthorized())
 		return
 	}
 
 	user, err := uc.Service.GetByID(userID)
 	if err != nil {
-		response.Error(c, http.StatusInternalServerError, *apperror.NewInternalServerError())
+		respondAPIError(c, apperror.NewInternalServerError())
 		return
 	}
 

--- a/backend/middleware/auth_middleware.go
+++ b/backend/middleware/auth_middleware.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"strings"
 
@@ -67,6 +66,8 @@ func AuthMiddleware() gin.HandlerFunc {
 }
 
 func abortUnauthorized(c *gin.Context) {
-	response.Error(c, http.StatusUnauthorized, *apperror.NewUnauthorized())
+	apiErr := apperror.NewUnauthorized()
+	status := apperror.MapErrorCodeToStatus(apiErr.Code)
+	response.Error(c, status, *apiErr)
 	c.Abort()
 }

--- a/docs/backend_refactoring_plan.md
+++ b/docs/backend_refactoring_plan.md
@@ -71,7 +71,7 @@ Issue #136 の調査結果をもとに、backend には以下の特徴がある�
 
 ### 2. 次フェーズ候補
 
-- [ ] apperror / response 利用方針の統一（APIError生成 helper 化まで実施）
+- [ ] apperror / response 利用方針の統一（MapErrorCodeToStatus 適用範囲整理まで実施）
 - [ ] controller 内 DTO 変換の重複整理
 - [ ] JWT / config 周りの責務整理
 
@@ -212,9 +212,9 @@ controller ごとの error response 組み立て：
 
 | controller | invalid request | validation error | unauthorized | not found | internal server error |
 | --- | --- | --- | --- | --- | --- |
-| `auth_controller.go` | `apperror.NewInvalidRequest` を `response.Error` で返す | controller で details を組み立て、`apperror.NewValidationError` を `response.Error` で返す | service error を `apperror.NewUnauthorized` + `response.Error` に変換 | なし | なし |
-| `user_controller.go` | `apperror.NewInvalidRequest` を `response.Error` で返す | controller で details を組み立て、`apperror.NewValidationError` を `response.Error` で返す | `GetMe` の context 不正時に `apperror.NewUnauthorized` + `response.Error` | なし | `apperror.NewInternalServerError` を `response.Error` で返す |
-| `task_controller.go` | path / JSON request 不正は `apperror.NewInvalidRequest` を `response.Error` で返す。service 由来の `INVALID_REQUEST` は `MapErrorCodeToStatus` 経由 | controller helper が `apperror.NewValidationError` を返し `response.Error`。`PATCH /tasks/:id` の JSON bind error は `VALIDATION_ERROR` | middleware 側で `apperror.NewUnauthorized` + `response.Error` + `c.Abort()` | service 由来の `NOT_FOUND` を `MapErrorCodeToStatus` 経由で返す | `apperror.NewInternalServerError` を `response.Error` で返す |
+| `auth_controller.go` | `apperror.NewInvalidRequest` を `MapErrorCodeToStatus` 経由で返す | controller で details を組み立て、`apperror.NewValidationError` を `MapErrorCodeToStatus` 経由で返す | service error を `apperror.NewUnauthorized` + `MapErrorCodeToStatus` 経由で返す | なし | なし |
+| `user_controller.go` | `apperror.NewInvalidRequest` を `MapErrorCodeToStatus` 経由で返す | controller で details を組み立て、`apperror.NewValidationError` を `MapErrorCodeToStatus` 経由で返す | `GetMe` の context 不正時に `apperror.NewUnauthorized` + `MapErrorCodeToStatus` 経由で返す | なし | `apperror.NewInternalServerError` を `MapErrorCodeToStatus` 経由で返す |
+| `task_controller.go` | path / JSON request 不正は `apperror.NewInvalidRequest` を `MapErrorCodeToStatus` 経由で返す。service 由来の `INVALID_REQUEST` も同じ経路で返す | controller helper が `apperror.NewValidationError` を返し、`MapErrorCodeToStatus` 経由で返す。`PATCH /tasks/:id` の JSON bind error は `VALIDATION_ERROR` | middleware 側で `apperror.NewUnauthorized` + `MapErrorCodeToStatus` + `c.Abort()` | service 由来の `NOT_FOUND` を `MapErrorCodeToStatus` 経由で返す | `apperror.NewInternalServerError` を `MapErrorCodeToStatus` 経由で返す |
 
 実施済み：
 
@@ -223,10 +223,11 @@ controller ごとの error response 組み立て：
 - `NewInternalServerError` / `NewUnauthorized` を追加した
 - `response.Unauthorized` は削除し、`response` は HTTP response 出力、`apperror` は APIError 生成を担当する形へ寄せた
 - middleware では unauthorized response 後に `c.Abort()` する制御を維持した
+- controller で返す `APIError` は `respondAPIError` を通して `MapErrorCodeToStatus` で HTTP status を決める形へ整理した
+- middleware の unauthorized response も `MapErrorCodeToStatus` で HTTP status を決める形へ整理した
 
 残っている揺れ・次に決めること：
 
-- service 由来の `APIError` だけでなく、controller 内の `APIError` にも `MapErrorCodeToStatus` を使うか
 - `ShouldBindJSON` 失敗時の endpoint ごとの差分を既存仕様として維持するか、API仕様との整合を確認して別Issueで扱うか
 - `Details: nil` の明示有無を統一対象に含めるか
 - auth service は通常の `error` を返し、controller が unauthorized へ変換している。この扱いを維持するか、service error を `apperror` 化するか
@@ -240,7 +241,8 @@ controller ごとの error response 組み立て：
 - [x] service から返す error と controller で返す response の関係を整理
 - [x] 既存挙動を変えずに `APIError` 生成 helper へ寄せる範囲を決める
 - [x] `APIError` 生成 helper 化を最小差分で実装する
-- [ ] `MapErrorCodeToStatus` の適用範囲を決める
+- [x] `MapErrorCodeToStatus` の適用範囲を決める
+- [x] controller / middleware の `APIError` response を `MapErrorCodeToStatus` 経由へ整理する
 - [ ] `ShouldBindJSON` 失敗時の endpoint 差分を扱うか決める
 
 ---


### PR DESCRIPTION
## ■ 目的

`apperror.MapErrorCodeToStatus` の適用範囲を整理し、controller 内で HTTP status を直接決める箇所の揺れを減らす。

Closes #161

---

## ■ 変更内容

- `backend/controller/error_response.go` を追加
- controller の `APIError` response を `respondAPIError()` 経由に整理
- `respondAPIError()` で `apperror.MapErrorCodeToStatus(apiErr.Code)` を使って HTTP status を決定
- service 由来 / controller 生成 / controller helper 由来の `APIError` response を同じ経路へ整理
- middleware の unauthorized response も `MapErrorCodeToStatus` 経由へ変更
- `docs/backend_refactoring_plan.md` に進捗を反映

---

## ■ 影響範囲

- Backend error response の HTTP status 決定処理
- `backend/controller/auth_controller.go`
- `backend/controller/user_controller.go`
- `backend/controller/task_controller.go`
- `backend/controller/error_response.go`
- `backend/middleware/auth_middleware.go`
- `docs/backend_refactoring_plan.md`

HTTP status / error.code / message / details / response envelope は維持。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [ ] コンソールエラーがない（API直接確認のため未確認）
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `go test ./...`（backend）成功
- `git diff --check` 成功
- API直接確認
  - `POST /users`: `201`
  - `POST /login`: `200`
  - `GET /me`: `200`
  - `GET /tasks`: `200`
  - `POST /tasks`: `201`
  - `PATCH /tasks/:id`: `200`
  - `DELETE /tasks/:id`: `200`
  - 認証なし: `401 UNAUTHORIZED`
  - invalid token: `401 UNAUTHORIZED`
  - user validation: `400 VALIDATION_ERROR`
  - login validation: `400 VALIDATION_ERROR`
  - task dueDate空文字 create: `201`, `dueDate: null`
  - task dueDate空文字 update: `400 VALIDATION_ERROR`
  - task not found: `404 NOT_FOUND`
  - malformed JSON: `400 INVALID_REQUEST`
  - invalid task id: `400 INVALID_REQUEST`
- `docker compose logs --tail 30 backend`
  - not found 確認時の `record not found` のみ確認

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: `APIError` の code から HTTP status を決める既存の対応表を controller / middleware の response 経路にも適用する整理であり、確認した API の HTTP status / error.code / message / details は維持されているため。

---

## ■ 懸念点・補足

- `ShouldBindJSON` 失敗時の endpoint 差分整理は対象外
- auth service の error 方針変更は対象外
- API確認用のユーザーはローカルDBに残っている可能性あり
- API確認用に作成したタスクは削除済み