### PR TITLE
backend ShouldBindJSON 失敗時の error response を整理

### DIFF
--- a/backend/controller/task_controller.go
+++ b/backend/controller/task_controller.go
@@ -93,7 +93,7 @@ func (tc *TaskController) UpdateTask(c *gin.Context) {
 
 	var input dto.UpdateTaskRequest
 	if err := c.ShouldBindJSON(&input); err != nil {
-		respondAPIError(c, apperror.NewValidationError("validation error", nil))
+		respondAPIError(c, apperror.NewInvalidRequest("invalid request"))
 		return
 	}
 

--- a/docs/backend_refactoring_plan.md
+++ b/docs/backend_refactoring_plan.md
@@ -69,9 +69,28 @@ Issue #136 の調査結果をもとに、backend には以下の特徴がある�
 - `POST /tasks` では `dueDate` 空文字を `nil` として扱い、`PATCH /tasks/:id` では validation error として扱う仕様差分を維持
 - `POST /tasks` で title と dueDate が同時に不正な場合は、validation details が配列であることに合わせて複数 details を返す
 
-### 2. 次フェーズ候補
+### 2. apperror / response 利用方針の統一
 
-- [ ] apperror / response 利用方針の統一（MapErrorCodeToStatus 適用範囲整理まで実施）
+- [x] controller ごとの error response 組み立て方を確認
+- [x] `apperror.APIError` の使われ方を確認
+- [x] `response.Error` の呼び出し方を確認
+- [x] `MapErrorCodeToStatus` の利用箇所を確認
+- [x] service から返す error と controller で返す response の関係を整理
+- [x] 既存挙動を変えずに `APIError` 生成 helper へ寄せる範囲を決定
+- [x] `APIError` 生成 helper 化を最小差分で実装
+- [x] `MapErrorCodeToStatus` の適用範囲を決定
+- [x] controller / middleware の `APIError` response を `MapErrorCodeToStatus` 経由へ整理
+- [x] `ShouldBindJSON` 失敗時の endpoint 差分を扱うか決定
+- [x] `ShouldBindJSON` 失敗時の error code を `INVALID_REQUEST` に統一
+
+補足：
+
+- `response` は HTTP response 出力、`apperror` は `APIError` 生成を担当する形へ整理済み
+- HTTP status は `APIError.Code` をもとに `MapErrorCodeToStatus` で決定する
+- JSON形式不正や型不正は validation error ではなく request形式不正として扱う
+
+### 3. 次フェーズ候補
+
 - [ ] controller 内 DTO 変換の重複整理
 - [ ] JWT / config 周りの責務整理
 
@@ -124,7 +143,7 @@ validation 種別ごとの責務案：
 
 - request形式
   - controller が担当する
-  - `ShouldBindJSON` 失敗時は既存どおり `INVALID_REQUEST` または現在の endpoint が返している error code を維持する
+  - `ShouldBindJSON` 失敗時は JSON形式不正または型不正として `INVALID_REQUEST` を返す
 - 必須チェック
   - 原則として controller または DTO validation 近辺で扱う
   - ただし既存レスポンスの `details[].field` / `details[].code` / `details[].message` を変えない
@@ -157,7 +176,7 @@ validation 種別ごとの責務案：
 - user登録は controller validation に整理済み
 - task作成は controller helper に必須チェック、日付形式チェック、空文字の `nil` 化がまとまっている
 - task更新は controller helper が request validation と補正を担当し、service が業務ルールと更新処理を担当する
-- `ShouldBindJSON` 失敗時の error code が endpoint によって `INVALID_REQUEST` と `VALIDATION_ERROR` に分かれている
+- `ShouldBindJSON` 失敗時の error code は `INVALID_REQUEST` に統一済み
 
 完了済み：
 
@@ -168,6 +187,7 @@ validation 種別ごとの責務案：
 5. task更新の service validation を、業務ルールと request validation に分けて整理する
 6. task title 最大長仕様差分を整理し、create/update で共通化する
 7. task validation helper を controller 本体から分離する
+8. `ShouldBindJSON` 失敗時の error code を `INVALID_REQUEST` に統一する
 
 仕様差分として維持しているもの：
 
@@ -214,7 +234,7 @@ controller ごとの error response 組み立て：
 | --- | --- | --- | --- | --- | --- |
 | `auth_controller.go` | `apperror.NewInvalidRequest` を `MapErrorCodeToStatus` 経由で返す | controller で details を組み立て、`apperror.NewValidationError` を `MapErrorCodeToStatus` 経由で返す | service error を `apperror.NewUnauthorized` + `MapErrorCodeToStatus` 経由で返す | なし | なし |
 | `user_controller.go` | `apperror.NewInvalidRequest` を `MapErrorCodeToStatus` 経由で返す | controller で details を組み立て、`apperror.NewValidationError` を `MapErrorCodeToStatus` 経由で返す | `GetMe` の context 不正時に `apperror.NewUnauthorized` + `MapErrorCodeToStatus` 経由で返す | なし | `apperror.NewInternalServerError` を `MapErrorCodeToStatus` 経由で返す |
-| `task_controller.go` | path / JSON request 不正は `apperror.NewInvalidRequest` を `MapErrorCodeToStatus` 経由で返す。service 由来の `INVALID_REQUEST` も同じ経路で返す | controller helper が `apperror.NewValidationError` を返し、`MapErrorCodeToStatus` 経由で返す。`PATCH /tasks/:id` の JSON bind error は `VALIDATION_ERROR` | middleware 側で `apperror.NewUnauthorized` + `MapErrorCodeToStatus` + `c.Abort()` | service 由来の `NOT_FOUND` を `MapErrorCodeToStatus` 経由で返す | `apperror.NewInternalServerError` を `MapErrorCodeToStatus` 経由で返す |
+| `task_controller.go` | path / JSON request 不正は `apperror.NewInvalidRequest` を `MapErrorCodeToStatus` 経由で返す。service 由来の `INVALID_REQUEST` も同じ経路で返す | controller helper が `apperror.NewValidationError` を返し、`MapErrorCodeToStatus` 経由で返す | middleware 側で `apperror.NewUnauthorized` + `MapErrorCodeToStatus` + `c.Abort()` | service 由来の `NOT_FOUND` を `MapErrorCodeToStatus` 経由で返す | `apperror.NewInternalServerError` を `MapErrorCodeToStatus` 経由で返す |
 
 実施済み：
 
@@ -225,25 +245,12 @@ controller ごとの error response 組み立て：
 - middleware では unauthorized response 後に `c.Abort()` する制御を維持した
 - controller で返す `APIError` は `respondAPIError` を通して `MapErrorCodeToStatus` で HTTP status を決める形へ整理した
 - middleware の unauthorized response も `MapErrorCodeToStatus` で HTTP status を決める形へ整理した
+- `PATCH /tasks/:id` の `ShouldBindJSON` 失敗時 response を `VALIDATION_ERROR` から `INVALID_REQUEST` へ変更し、他 endpoint と揃えた
 
 残っている揺れ・次に決めること：
 
-- `ShouldBindJSON` 失敗時の endpoint ごとの差分を既存仕様として維持するか、API仕様との整合を確認して別Issueで扱うか
 - `Details: nil` の明示有無を統一対象に含めるか
 - auth service は通常の `error` を返し、controller が unauthorized へ変換している。この扱いを維持するか、service error を `apperror` 化するか
-
-今回の到達点：
-
-- [x] controller ごとの error response 組み立て方を確認
-- [x] `apperror.APIError` の使われ方を確認
-- [x] `response.Error` の呼び出し方を確認
-- [x] `MapErrorCodeToStatus` の利用箇所を確認
-- [x] service から返す error と controller で返す response の関係を整理
-- [x] 既存挙動を変えずに `APIError` 生成 helper へ寄せる範囲を決める
-- [x] `APIError` 生成 helper 化を最小差分で実装する
-- [x] `MapErrorCodeToStatus` の適用範囲を決める
-- [x] controller / middleware の `APIError` response を `MapErrorCodeToStatus` 経由へ整理する
-- [ ] `ShouldBindJSON` 失敗時の endpoint 差分を扱うか決める
 
 ---
 


### PR DESCRIPTION
## ■ 目的

`ShouldBindJSON` 失敗時に返す error response の差分を整理し、JSON形式不正・型不正を request形式不正として扱う方針に統一する。

Closes #163

---

## ■ 変更内容

- `PATCH /tasks/:id` の `ShouldBindJSON` 失敗時 response を `VALIDATION_ERROR` から `INVALID_REQUEST` へ変更
- `POST /users` / `POST /login` / `POST /tasks` / `PATCH /tasks/:id` の `ShouldBindJSON` 失敗時 error code を `INVALID_REQUEST` に統一
- `docs/backend_refactoring_plan.md` の進捗サマリと error handling 方針を更新
- step2（apperror / response 利用方針の統一）の到達点を進捗サマリへ整理

---

## ■ 影響範囲

- Backend `PATCH /tasks/:id` の JSON形式不正・型不正 response
- `backend/controller/task_controller.go`
- `docs/backend_refactoring_plan.md`

通常の validation error（例: `dueDate` 空文字）は従来どおり `VALIDATION_ERROR` を返す。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない（一部、仕様整合のため意図的な error code 変更あり）
* [x] 対象機能が正常に動作する
* [ ] コンソールエラーがない（API直接確認のため未確認）
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `go test ./...`（backend）成功
- `git diff --check` 成功
- API直接確認
  - `POST /users`: `201`
  - `POST /login`: `200`
  - `GET /me`: `200`
  - `POST /tasks`: `201`
  - `PATCH /tasks/:id`: `200`
  - 認証なし: `401 UNAUTHORIZED`
  - `POST /users` malformed JSON: `400 INVALID_REQUEST`
  - `POST /login` malformed JSON: `400 INVALID_REQUEST`
  - `POST /tasks` malformed JSON: `400 INVALID_REQUEST`
  - `PATCH /tasks/:id` malformed JSON: `400 INVALID_REQUEST`
  - `PATCH /tasks/:id` 型不正: `400 INVALID_REQUEST`
  - `PATCH /tasks/:id` dueDate空文字 validation: `400 VALIDATION_ERROR`
  - `PATCH /tasks/:id` not found: `404 NOT_FOUND`
  - `DELETE /tasks/:id`: `200`
- `docker compose logs --tail 25 backend`
  - not found 確認時の `record not found` のみ確認

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Medium
* 理由: 変更範囲は `ShouldBindJSON` 失敗時 response に限定しているが、`PATCH /tasks/:id` の malformed JSON / 型不正時の `error.code` が `VALIDATION_ERROR` から `INVALID_REQUEST` に変わるため。

---

## ■ 懸念点・補足

- `ShouldBindJSON` 失敗は JSON形式不正・型不正として扱い、validation error とは分けている
- auth service の error 方針変更は対象外
- `Details: nil` の明示有無整理は今後の検討として残している
- API確認用のユーザーはローカルDBに残っている可能性あり
- API確認用に作成したタスクは削除済み