### PR TITLE
backend: controller内DTO変換重複を整理

### DIFF
--- a/backend/controller/task_controller.go
+++ b/backend/controller/task_controller.go
@@ -43,12 +43,7 @@ func (tc *TaskController) CreateTask(c *gin.Context) {
 		return
 	}
 
-	res := dto.TaskResponse{
-		ID:        createdTask.ID,
-		Title:     createdTask.Title,
-		Completed: createdTask.Completed,
-		DueDate:   createdTask.DueDate,
-	}
+	res := dto.NewTaskResponse(&createdTask)
 
 	response.SuccessCreated(c, gin.H{
 		"task": res,
@@ -64,16 +59,7 @@ func (tc *TaskController) GetTasks(c *gin.Context) {
 		return
 	}
 
-	res := make([]dto.TaskResponse, 0, len(tasks))
-
-	for _, t := range tasks {
-		res = append(res, dto.TaskResponse{
-			ID:        t.ID,
-			Title:     t.Title,
-			Completed: t.Completed,
-			DueDate:   t.DueDate,
-		})
-	}
+	res := dto.NewTaskResponses(tasks)
 
 	response.Success(c, gin.H{
 		"tasks": res,
@@ -113,12 +99,7 @@ func (tc *TaskController) UpdateTask(c *gin.Context) {
 		return
 	}
 
-	res := dto.TaskResponse{
-		ID:        task.ID,
-		Title:     task.Title,
-		Completed: task.Completed,
-		DueDate:   task.DueDate,
-	}
+	res := dto.NewTaskResponse(task)
 
 	response.Success(c, gin.H{
 		"task": res,

--- a/backend/controller/user_controller.go
+++ b/backend/controller/user_controller.go
@@ -27,14 +27,7 @@ func (uc *UserController) GetUsers(c *gin.Context) {
 		return
 	}
 
-	res := make([]dto.UserResponse, 0, len(users))
-	for _, u := range users {
-		res = append(res, dto.UserResponse{
-			ID:    u.ID,
-			Name:  u.Name,
-			Email: u.Email,
-		})
-	}
+	res := dto.NewUserResponses(users)
 
 	response.Success(c, gin.H{
 		"users": res,
@@ -106,11 +99,7 @@ func (uc *UserController) CreateUser(c *gin.Context) {
 		return
 	}
 
-	res := dto.UserResponse{
-		ID:    createdUser.ID,
-		Name:  createdUser.Name,
-		Email: createdUser.Email,
-	}
+	res := dto.NewUserResponse(createdUser)
 	response.SuccessCreated(c, gin.H{
 		"user": res,
 	})
@@ -136,11 +125,7 @@ func (uc *UserController) GetMe(c *gin.Context) {
 		return
 	}
 
-	res := dto.UserResponse{
-		ID:    user.ID,
-		Name:  user.Name,
-		Email: user.Email,
-	}
+	res := dto.NewUserResponse(user)
 	response.Success(c, gin.H{
 		"user": res,
 	})

--- a/backend/dto/task_dto.go
+++ b/backend/dto/task_dto.go
@@ -1,5 +1,7 @@
 package dto
 
+import "github.com/msubaru14/my-app-backend/model"
+
 type CreateTaskInput struct {
 	Title   string  `json:"title"`
 	DueDate *string `json:"dueDate"`
@@ -10,6 +12,24 @@ type TaskResponse struct {
 	Title     string  `json:"title"`
 	Completed bool    `json:"completed"`
 	DueDate   *string `json:"dueDate"`
+}
+
+func NewTaskResponse(task *model.Task) TaskResponse {
+	return TaskResponse{
+		ID:        task.ID,
+		Title:     task.Title,
+		Completed: task.Completed,
+		DueDate:   task.DueDate,
+	}
+}
+
+func NewTaskResponses(tasks []model.Task) []TaskResponse {
+	responses := make([]TaskResponse, 0, len(tasks))
+	for i := range tasks {
+		responses = append(responses, NewTaskResponse(&tasks[i]))
+	}
+
+	return responses
 }
 
 type UpdateTaskRequest struct {

--- a/backend/dto/user_dto.go
+++ b/backend/dto/user_dto.go
@@ -1,5 +1,7 @@
 package dto
 
+import "github.com/msubaru14/my-app-backend/model"
+
 type CreateUserInput struct {
 	Name     string `json:"name"`
 	Email    string `json:"email"`
@@ -10,4 +12,21 @@ type UserResponse struct {
 	ID    uint   `json:"id"`
 	Name  string `json:"name"`
 	Email string `json:"email"`
+}
+
+func NewUserResponse(user *model.User) UserResponse {
+	return UserResponse{
+		ID:    user.ID,
+		Name:  user.Name,
+		Email: user.Email,
+	}
+}
+
+func NewUserResponses(users []model.User) []UserResponse {
+	responses := make([]UserResponse, 0, len(users))
+	for i := range users {
+		responses = append(responses, NewUserResponse(&users[i]))
+	}
+
+	return responses
 }

--- a/docs/backend_refactoring_plan.md
+++ b/docs/backend_refactoring_plan.md
@@ -89,9 +89,17 @@ Issue #136 の調査結果をもとに、backend には以下の特徴がある�
 - HTTP status は `APIError.Code` をもとに `MapErrorCodeToStatus` で決定する
 - JSON形式不正や型不正は validation error ではなく request形式不正として扱う
 
+### 3. controller 内 DTO 変換の重複整理
+
+- [x] controller 内 DTO 変換の重複整理
+
+補足：
+
+- `UserResponse` / `TaskResponse` の生成処理は DTO 側の変換 helper へ整理済み
+- controller 側は既存の `data` / `error` 構造を維持したまま、DTO 変換 helper を呼び出す形へ整理済み
+
 ### 3. 次フェーズ候補
 
-- [ ] controller 内 DTO 変換の重複整理
 - [ ] JWT / config 周りの責務整理
 
 ---
@@ -256,7 +264,7 @@ controller ごとの error response 組み立て：
 
 ### 3. controller 内 DTO 変換の重複整理
 
-優先度：中
+優先度：完了
 
 目的：
 
@@ -274,6 +282,12 @@ controller ごとの error response 組み立て：
 
 - 過剰な抽象化は行わない
 - mapper 層などの新しい大きな設計は導入しない
+
+完了済み：
+
+1. `UserResponse` / `TaskResponse` の生成 helper を DTO 側へ追加する
+2. controller 内の手書き response DTO 生成を helper 呼び出しへ置き換える
+3. APIレスポンスのキー名・構造を維持する
 
 ---
 

--- a/docs/backend_refactoring_plan.md
+++ b/docs/backend_refactoring_plan.md
@@ -98,7 +98,7 @@ Issue #136 の調査結果をもとに、backend には以下の特徴がある�
 - `UserResponse` / `TaskResponse` の生成処理は DTO 側の変換 helper へ整理済み
 - controller 側は既存の `data` / `error` 構造を維持したまま、DTO 変換 helper を呼び出す形へ整理済み
 
-### 3. 次フェーズ候補
+### 4. 次フェーズ候補
 
 - [ ] JWT / config 周りの責務整理
 


### PR DESCRIPTION
## ■ 目的

controller 内で重複していた `UserResponse` / `TaskResponse` の DTO 変換処理を整理し、controller の責務を HTTP request / response 制御へ寄せる。

Closes #165

---

## ■ 変更内容

- `dto.NewUserResponse` / `dto.NewUserResponses` を追加
- `dto.NewTaskResponse` / `dto.NewTaskResponses` を追加
- `user_controller.go` / `task_controller.go` の手書き response DTO 生成を helper 呼び出しへ置き換え
- `docs/backend_refactoring_plan.md` に controller 内 DTO 変換整理の完了状況を反映

---

## ■ 影響範囲

- Backend API の user / task response DTO 生成処理
- 対象 endpoint:
  - `GET /users`
  - `POST /users`
  - `GET /me`
  - `POST /tasks`
  - `GET /tasks`
  - `PATCH /tasks/:id`

API レスポンス構造、JSON キー、validation、error handling、認証・認可挙動、DB スキーマは変更しない。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `go test ./...`（backend）
- `git diff --check`
- API 動作確認:
  - `POST /users`: `201`
  - `POST /login`: `200`
  - `GET /me`: `200`
  - `GET /users`: `200`
  - `POST /tasks`: `201`
  - `GET /tasks`: `200`
  - `PATCH /tasks/:id`: `200`
  - `POST /tasks` validation error: `400 VALIDATION_ERROR details=2`
  - `GET /tasks` unauthorized: `401 UNAUTHORIZED`
  - `DELETE /tasks/:id`: `200`

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: DTO 変換処理の配置整理のみで、API レスポンス構造・validation・error handling・認証認可・DB スキーマを変更していないため。

---

## ■ 懸念点・補足

- ブラウザ画面操作ではなく、backend API への直接リクエストで動作確認した。
- docs は backend refactoring Step3 の完了反映のみ。