### PR TITLE
backend: JWT_SECRET取得責務を整理

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/msubaru14/my-app-backend/controller"
 	"github.com/msubaru14/my-app-backend/db"
+	"github.com/msubaru14/my-app-backend/pkg/config"
 	"github.com/msubaru14/my-app-backend/repository"
 	"github.com/msubaru14/my-app-backend/router"
 	"github.com/msubaru14/my-app-backend/service"
 )
 
 func main() {
-	if os.Getenv("JWT_SECRET") == "" {
+	if config.JWTSecret() == "" {
 		log.Fatal("JWT_SECRET is required")
 	}
 

--- a/backend/middleware/auth_middleware.go
+++ b/backend/middleware/auth_middleware.go
@@ -2,12 +2,12 @@ package middleware
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/msubaru14/my-app-backend/pkg/apperror"
+	"github.com/msubaru14/my-app-backend/pkg/config"
 	"github.com/msubaru14/my-app-backend/pkg/response"
 )
 
@@ -32,7 +32,7 @@ func AuthMiddleware() gin.HandlerFunc {
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 				return nil, fmt.Errorf("unexpected signing method")
 			}
-			return []byte(os.Getenv("JWT_SECRET")), nil
+			return []byte(config.JWTSecret()), nil
 		})
 
 		if err != nil || !token.Valid {

--- a/backend/pkg/config/jwt.go
+++ b/backend/pkg/config/jwt.go
@@ -1,0 +1,9 @@
+package config
+
+import "os"
+
+const jwtSecretEnv = "JWT_SECRET"
+
+func JWTSecret() string {
+	return os.Getenv(jwtSecretEnv)
+}

--- a/backend/utils/jwt.go
+++ b/backend/utils/jwt.go
@@ -1,13 +1,11 @@
 package utils
 
 import (
-	"os"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/msubaru14/my-app-backend/pkg/config"
 )
-
-var secretKey = []byte(os.Getenv("JWT_SECRET"))
 
 func GenerateJWT(userID uint) (string, error) {
 	claims := jwt.MapClaims{
@@ -17,5 +15,5 @@ func GenerateJWT(userID uint) (string, error) {
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 
-	return token.SignedString(secretKey)
+	return token.SignedString([]byte(config.JWTSecret()))
 }

--- a/docs/backend_refactoring_plan.md
+++ b/docs/backend_refactoring_plan.md
@@ -100,7 +100,13 @@ Issue #136 の調査結果をもとに、backend には以下の特徴がある�
 
 ### 4. 次フェーズ候補
 
-- [ ] JWT / config 周りの責務整理
+- [x] JWT_SECRET 取得責務の整理
+
+補足：
+
+- `JWT_SECRET` の取得口は `pkg/config` の helper へ整理済み
+- 起動時チェック、token生成、token検証は同じ helper を経由する形へ整理済み
+- JWT仕様、claim名、有効期限、認証・認可挙動は維持
 
 ---
 
@@ -311,6 +317,20 @@ controller ごとの error response 組み立て：
 
 - auth 周辺は影響範囲が広いため、validation/error handling と同じPRで扱わない
 - package init 時の環境変数取得を見直す場合は、起動時挙動の確認を必須にする
+
+完了済み：
+
+1. `JWT_SECRET` の参照箇所を確認する
+2. `JWT_SECRET` の取得口を `pkg/config` に集約する
+3. `utils` の package init 時取得をやめ、token生成時に config helper 経由で取得する
+4. middleware の token検証時取得を config helper 経由へ揃える
+
+維持しているもの：
+
+- JWT署名方式
+- `user_id` claim
+- token有効期限
+- unauthorized response
 
 ---
 


### PR DESCRIPTION
## ■ 目的

JWT / config 周りの責務整理の第一段階として、`JWT_SECRET` の取得口を明確にし、起動時チェック・token生成・token検証で同じ config helper を使う形へ整理する。

Closes #167

---

## ■ 変更内容

- `backend/pkg/config/jwt.go` を追加し、`JWT_SECRET` の取得 helper を定義
- `main.go` の起動時 `JWT_SECRET` チェックを config helper 経由へ変更
- `utils/jwt.go` の package init 時 `JWT_SECRET` 取得をやめ、token生成時に config helper 経由で取得する形へ変更
- `auth_middleware.go` の token検証時 `JWT_SECRET` 取得を config helper 経由へ変更
- `docs/backend_refactoring_plan.md` に Step4 の進捗を反映

---

## ■ 影響範囲

- Backend の JWT secret 取得処理
- token生成処理
- token検証処理
- 認証 middleware
- 起動時の `JWT_SECRET` 必須チェック

JWT署名方式、`user_id` claim、token有効期限、認証・認可ロジック、unauthorized response、APIレスポンス形式は変更しない。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `go test ./...`（backend）
- `git diff --check`
- Docker上のbackend再ビルド・起動ログ確認
- API 動作確認:
  - `POST /users`: `201`
  - `POST /login`: `200`
  - `GET /me`: `200`
  - `POST /tasks`: `201`
  - `GET /tasks`: `200`
  - tokenなし `GET /me`: `401 UNAUTHORIZED`
  - invalid token `GET /me`: `401 UNAUTHORIZED`
  - `DELETE /tasks/:id`: `200`

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Medium
* 理由: 認証基盤に関わる `JWT_SECRET` の取得経路を変更しているため。ただし、JWT仕様・claim名・有効期限・認証レスポンスは変更せず、取得口の集約に限定している。

---

## ■ 懸念点・補足

- ブラウザ画面操作ではなく、backend API への直接リクエストで認証挙動を確認した。
- `PORT` など他の環境変数取得は今回の対象外。