### PR TITLE
docs: finalize backend design policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ HTTP PATCHの思想に沿い、フロントからの差分更新に柔軟に対�
 - Service: ビジネスロジック
 - Repository: DB操作
 
+### バックエンド設計方針
+
+バックエンドは controller -> service -> repository の3層構成を維持します。
+
+- Controller: HTTP request / response の制御
+- Service: 業務ルール、所有者チェック、更新可否判断
+- Repository: DBアクセス
+
+現時点では usecase 層や repository interface は導入していません。
+本アプリの規模では、まず既存3層の責務を明確にし、過剰な抽象化を避ける方針です。
+
+一方で、`TaskService` のように業務ルールが集まりやすい箇所では、service が HTTP request DTO に依存しすぎないよう service input の導入を検討します。
+repository interface は、unit test 導入時に DB 依存を切り離す必要が明確になった範囲から最小限で検討します。
+
+詳細は [backend設計方針](./docs/backend_design_policy.md) を参照してください。
+
 ### フロントエンド構成
 
 フロントエンドは feature 単位で画面・API・型・補助ロジックをまとめています。
@@ -210,9 +226,10 @@ docker compose up --build -d
 
 
 ## 🚧 今後の予定
-- 今日以外のタスク表示
-- UI/UXの改善
-- 認証強化（リフレッシュトークン）
+- TaskService など業務ルールが多い箇所から unit test を小さく追加
+- service input 導入による request DTO 依存の整理
+- 無料PaaS構成でのデプロイ
+- 必要に応じたUI/UX改善
 
 
 ## 🧠 設計の特徴
@@ -224,13 +241,33 @@ docker compose up --build -d
 - APIエラーの分類と表示用メッセージ整形を `useApiError` に集約
 - 認証・タスク管理を feature 単位で分離し、変更範囲を追いやすい構成に整理
 - feature の公開口を `index.ts` にまとめ、利用側から見える依存を簡潔に維持
+- backend は controller -> service -> repository の3層構成を維持
+- usecase 層や repository interface は、必要性が明確になるまで導入しない
+- service input / unit test は、業務ルールが多い箇所から小さく検討
 👉 実務を意識した設計にしています
 
 
-## ⚠️ 今後の改善・拡張予定
-- バリデーションロジックのService層への集約
-- テストコードの追加
-- レスポンシブ対応
+## ✅ 完成条件
+
+本アプリは、機能を増やし続けることよりも「設計と保守性を意識したWebアプリ」として完成させることを重視します。
+
+- ユーザー登録 / ログイン / ログインユーザー取得が安定して動作する
+- タスク作成 / 一覧 / 更新 / 削除が安定して動作する
+- API仕様、エラー形式、dueDate 仕様がドキュメント化されている
+- backend の責務分離方針を説明できる
+- frontend の feature 分割と error handling 方針を説明できる
+- TaskService など重要な業務ルールに unit test を小さく導入している
+- 無料PaaS構成でデプロイできる状態になっている
+
+## ☁️ デプロイ方針
+
+ポートフォリオとして公開しやすいよう、無料枠で始められるPaaS構成を想定します。
+
+- Frontend: Vercel
+- Backend: Render
+- Database: Neon
+
+デプロイ時も、API仕様・認証挙動・DBスキーマを変更しない方針を維持します。
 
 
 ## 📄 ライセンス

--- a/docs/backend_design_improvement_plan.md
+++ b/docs/backend_design_improvement_plan.md
@@ -1,11 +1,11 @@
-# backend設計改善フェーズ 方針
+# backend設計改善フェーズ 調査書
 
 ## ■ 目的
 
 backend リファクタリング完了後の次フェーズとして、controller / service / repository の責務境界を確認し、今後の設計改善候補を整理する。
 
-このフェーズでは、実装変更や新アーキテクチャ導入を前提にしない。
-まず現状構成の痛み・限界・改善余地を確認し、必要性ベースで判断できる状態を作る。
+このドキュメントは、backend設計改善フェーズの判断材料をまとめた調査書として扱う。
+最終的な採用方針は `docs/backend_design_policy.md` に整理する。
 
 ---
 
@@ -267,9 +267,7 @@ task service は `apperror.APIError` を返す箇所がある。
 
 ## ■ 次の進め方
 
-1. service error 方針を整理する
-2. `TaskService.UpdateTask` の入力型依存を整理するか検討する
-3. user / auth validation helper 分離の必要性を確認する
-4. task service が厚くなる兆候を小さく観察する
+1. 調査結果をもとに、backend設計方針を `docs/backend_design_policy.md` に整理する
+2. 実装変更を伴う項目は別 Issue として分割する
 
 各項目は、実装変更を伴う場合は別 Issue として分割する。

--- a/docs/backend_design_policy.md
+++ b/docs/backend_design_policy.md
@@ -1,0 +1,131 @@
+# backend設計方針
+
+## ■ 目的
+
+backend設計改善フェーズの最終判断をまとめる。
+
+このドキュメントは、現時点で採用する構成、今は導入しない設計、今後の導入判断を説明できる状態にするための方針書として扱う。
+
+---
+
+## ■ 採用する構成
+
+backend は controller / service / repository の3層構成を維持する。
+
+- controller: HTTP request / response の制御
+- service: 業務ルール、所有者チェック、更新可否判断
+- repository: DBアクセス
+
+現時点では、usecase 層を追加せず、既存3層の責務を明確にすることを優先する。
+
+---
+
+## ■ service input の扱い
+
+service が HTTP request DTO に依存しすぎないよう、必要な箇所から service input の導入を検討する。
+
+優先候補：
+
+- `TaskService.UpdateTask`
+
+方針：
+
+- controller は request DTO を受け取り、必要に応じて service input へ変換する
+- service は HTTP request の形状を直接意識しすぎない形を目指す
+- ただし、型追加による差分と効果を比較し、実装変更は別 Issue で扱う
+
+---
+
+## ■ usecase 層の扱い
+
+現時点では usecase 層を導入しない。
+
+理由：
+
+- 現状のタスク管理アプリでは、複数 service / repository をまたぐ orchestration が少ない
+- controller が複雑な業務手順を抱えている状態ではない
+- 3層構成と service input の整理で対応できる可能性が高い
+- 構造を増やすより、既存責務を明確にする方が現状規模に合っている
+
+導入を再検討する条件：
+
+- 複数 service / repository をまたぐ処理が増える
+- controller が usecase 手順を知りすぎる
+- service が HTTP 入力や response 都合を強く意識し始める
+- 複数操作を1つの業務単位としてまとめる必要が出る
+
+---
+
+## ■ repository interface の扱い
+
+現時点では repository interface を導入しない。
+
+理由：
+
+- 抽象化のためだけの interface は避ける
+- repository 実装を差し替える具体的な予定がない
+- unit test 導入時に必要性が明確になってから最小限で判断する方が安全
+
+導入を再検討する条件：
+
+- service の unit test で DB 依存を切り離す必要が高くなる
+- repository 実装を差し替える具体的な理由が出る
+- interface が利用側の要件として自然に定義できる
+
+---
+
+## ■ unit test 導入方針
+
+unit test は一括導入せず、業務ルールが多い箇所から小さく追加する。
+
+優先候補：
+
+- `TaskService.UpdateTask`
+- `TaskService.DeleteTask`
+- task validation helper
+- auth / user の重要な分岐
+
+方針：
+
+- まず service の業務ルールを確認しやすいテストから始める
+- DB 依存が強い場合は、repository interface の必要性をその時点で判断する
+- API response 形式の確認は、必要に応じて handler / integration test として別途扱う
+- unit test 実装は別 Issue として小さく進める
+
+---
+
+## ■ 完成条件
+
+本アプリは「設計と保守性を意識したWebアプリ」として完成を目指す。
+
+完成条件：
+
+- ユーザー登録 / ログイン / ログインユーザー取得が安定して動作する
+- タスク作成 / 一覧 / 更新 / 削除が安定して動作する
+- API仕様、エラー形式、dueDate 仕様がドキュメント化されている
+- backend の責務分離方針を説明できる
+- frontend の feature 分割と error handling 方針を説明できる
+- TaskService など重要な業務ルールに unit test を小さく導入している
+- 無料PaaS構成でデプロイできる状態になっている
+
+---
+
+## ■ デプロイ方針
+
+ポートフォリオとして公開しやすいよう、無料枠で始められるPaaS構成を想定する。
+
+- Frontend: Vercel
+- Backend: Render
+- Database: Neon
+
+デプロイ時も、API仕様・認証挙動・DBスキーマを変更しない方針を維持する。
+
+---
+
+## ■ 次の進め方
+
+1. `TaskService.UpdateTask` の service input 導入要否を検討する
+2. TaskService から unit test を小さく導入する
+3. unit test 導入時に repository interface の必要性を確認する
+4. service error 方針を整理する
+5. user / auth validation helper 分離の必要性を確認する

--- a/docs/backend_refactoring_plan.md
+++ b/docs/backend_refactoring_plan.md
@@ -17,6 +17,9 @@ validation、error handling、DTO変換、JWT/config、dueDate、DB/migration �
 controller / service / repository の責務境界見直しは、単なる構造整理ではなく設計判断を伴うため、
 次フェーズの **backend設計改善フェーズ** で別途扱う。
 
+backend設計改善フェーズの調査結果は `docs/backend_design_improvement_plan.md`、判断結果は `docs/backend_design_policy.md` に整理する。
+現時点では controller / service / repository の3層構成を維持し、usecase 層や repository interface は必要性が明確になった時点で小さく検討する。
+
 ---
 
 ## ■ 基本原則
@@ -496,6 +499,13 @@ controller ごとの error response 組み立て：
 - 責務が詰まり始めている箇所を整理する
 - 現行レイヤード構成のまま改善できる範囲を整理する
 - usecase 層などの導入必要性は、現状の痛みを確認したうえで検討材料として扱う
+
+判断結果：
+
+- controller / service / repository の3層構成は維持する
+- usecase 層は現時点では導入しない
+- service input は、HTTP request DTO 依存を弱める目的で必要箇所から検討する
+- repository interface は、unit test 導入時に必要性が明確な範囲で検討する
 
 ---
 


### PR DESCRIPTION
## ■ 目的

backend設計改善フェーズの最終判断をドキュメントへ反映し、現在の設計方針・導入判断・完成条件を説明可能な状態へ整理する。

Closes #181

---

## ■ 変更内容

- `docs/backend_design_policy.md` を新規作成
  - controller / service / repository の3層構成維持を明文化
  - service input の扱いを整理
  - usecase 層を現時点で導入しない理由を整理
  - repository interface を unit test 導入時に必要最小限で検討する方針を整理
  - unit test 導入方針、完成条件、デプロイ方針を整理
- `docs/backend_design_improvement_plan.md` を調査書として整理
- `docs/backend_refactoring_plan.md` に調査書 / 方針書の参照関係と判断結果を追記
- `README.md` に backend 設計方針、今後の予定、設計の特徴、完成条件、デプロイ方針を反映

---

## ■ 影響範囲

- docs のみ
- Goコード変更なし
- API仕様変更なし
- 認証・認可挙動変更なし
- DBスキーマ変更なし
- UI変更なし

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `git diff --check`
- `git diff --cached --check`
- hidden/control/odd-space chars 検出なし
- docs-only 変更のため、アプリ起動・API動作確認・ブラウザ確認は対象外

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: ドキュメントのみの変更で、実装・API・認証・DB・UI に影響しないため。

---

## ■ 懸念点・補足

- 今回は backend設計改善フェーズの締めとして、方針と判断理由を文書化するのみ
- service input / unit test / repository interface などの実装変更は、必要に応じて別 Issue で小さく扱う想定