### PR TITLE
TaskService.UpdateTask に service input を導入する

### DIFF
--- a/backend/controller/task_controller.go
+++ b/backend/controller/task_controller.go
@@ -88,7 +88,14 @@ func (tc *TaskController) UpdateTask(c *gin.Context) {
 		return
 	}
 
-	task, err := tc.Service.UpdateTask(uint(id), userID, input)
+	updateInput := service.UpdateTaskInput{
+		Title:      input.Title,
+		DueDateSet: input.DueDate.IsSet,
+		DueDate:    input.DueDate.Value,
+		Completed:  input.Completed,
+	}
+
+	task, err := tc.Service.UpdateTask(uint(id), userID, updateInput)
 	if err != nil {
 		if apiErr, ok := err.(*apperror.APIError); ok {
 			respondAPIError(c, apiErr)

--- a/backend/service/task_input.go
+++ b/backend/service/task_input.go
@@ -1,0 +1,8 @@
+package service
+
+type UpdateTaskInput struct {
+	Title      *string
+	DueDateSet bool
+	DueDate    *string
+	Completed  *bool
+}

--- a/backend/service/task_service.go
+++ b/backend/service/task_service.go
@@ -3,7 +3,6 @@ package service
 import (
 	"errors"
 
-	"github.com/msubaru14/my-app-backend/dto"
 	"github.com/msubaru14/my-app-backend/model"
 	"github.com/msubaru14/my-app-backend/pkg/apperror"
 	"github.com/msubaru14/my-app-backend/repository"
@@ -25,8 +24,8 @@ func (s *TaskService) GetTasksByUser(userID uint) ([]model.Task, error) {
 }
 
 // タスク更新
-func (s *TaskService) UpdateTask(id uint, userID uint, req dto.UpdateTaskRequest) (*model.Task, error) {
-	if !hasUpdateTaskFields(req) {
+func (s *TaskService) UpdateTask(id uint, userID uint, input UpdateTaskInput) (*model.Task, error) {
+	if !hasUpdateTaskFields(input) {
 		return nil, apperror.NewInvalidRequest("no fields to update")
 	}
 
@@ -39,16 +38,16 @@ func (s *TaskService) UpdateTask(id uint, userID uint, req dto.UpdateTaskRequest
 		return nil, err
 	}
 
-	if req.Title != nil {
-		task.Title = *req.Title
+	if input.Title != nil {
+		task.Title = *input.Title
 	}
 
-	if req.DueDate.IsSet {
-		task.DueDate = req.DueDate.Value
+	if input.DueDateSet {
+		task.DueDate = input.DueDate
 	}
 
-	if req.Completed != nil {
-		task.Completed = *req.Completed
+	if input.Completed != nil {
+		task.Completed = *input.Completed
 	}
 
 	// タスク更新
@@ -59,8 +58,8 @@ func (s *TaskService) UpdateTask(id uint, userID uint, req dto.UpdateTaskRequest
 	return task, nil
 }
 
-func hasUpdateTaskFields(req dto.UpdateTaskRequest) bool {
-	return req.Title != nil || req.DueDate.IsSet || req.Completed != nil
+func hasUpdateTaskFields(input UpdateTaskInput) bool {
+	return input.Title != nil || input.DueDateSet || input.Completed != nil
 }
 
 // タスク削除


### PR DESCRIPTION
## ■ 目的

`TaskService.UpdateTask` が `dto.UpdateTaskRequest` に直接依存している状態を整理し、service が HTTP request DTO を直接扱わない形に近づける。

Closes #183

---

## ■ 変更内容

- `backend/service/task_input.go` を追加し、`UpdateTaskInput` を定義
- `TaskService.UpdateTask` の引数を `dto.UpdateTaskRequest` から `service.UpdateTaskInput` に変更
- controller 側で `dto.UpdateTaskRequest` から `service.UpdateTaskInput` へ変換してから service を呼び出すよう変更
- `dueDate` の未指定 / null / 値ありの区別を `DueDateSet` / `DueDate` で維持

---

## ■ 影響範囲

- Backend の `PATCH /tasks/:id` 内部実装
- API仕様、レスポンス形式、DBスキーマ、frontend への影響なし

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [ ] コンソールエラーがない
* [ ] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `git diff --check`
- `cd backend && go test ./...`

補足:

- 今回は backend の構造整理のみのため、ブラウザでのコンソール確認は未実施
- APIを起動しての認証なし / invalid token / not found / validation error の手動確認は未実施

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: `TaskService.UpdateTask` の入力型を差し替えるのみで、既存の更新判定・所有者チェック・not found 判定・dueDate反映処理は維持しているため。

---

## ■ 懸念点・補足

- service input 導入の最小実例として、今回は `TaskService.UpdateTask` のみに限定
- usecase 層、repository interface、DTO全体の再設計は導入していない
