### PR TITLE
TaskService.UpdateTask の更新適用処理を分離する

### DIFF
--- a/backend/service/task_service.go
+++ b/backend/service/task_service.go
@@ -38,17 +38,7 @@ func (s *TaskService) UpdateTask(id uint, userID uint, input UpdateTaskInput) (*
 		return nil, err
 	}
 
-	if input.Title != nil {
-		task.Title = *input.Title
-	}
-
-	if input.DueDateSet {
-		task.DueDate = input.DueDate
-	}
-
-	if input.Completed != nil {
-		task.Completed = *input.Completed
-	}
+	applyUpdateTaskInput(task, input)
 
 	// タスク更新
 	if err := s.Repo.Update(task); err != nil {
@@ -60,6 +50,20 @@ func (s *TaskService) UpdateTask(id uint, userID uint, input UpdateTaskInput) (*
 
 func hasUpdateTaskFields(input UpdateTaskInput) bool {
 	return input.Title != nil || input.DueDateSet || input.Completed != nil
+}
+
+func applyUpdateTaskInput(task *model.Task, input UpdateTaskInput) {
+	if input.Title != nil {
+		task.Title = *input.Title
+	}
+
+	if input.DueDateSet {
+		task.DueDate = input.DueDate
+	}
+
+	if input.Completed != nil {
+		task.Completed = *input.Completed
+	}
 }
 
 // タスク削除


### PR DESCRIPTION
## ■ 目的

`TaskService.UpdateTask` の更新値反映処理を helper に分離し、後続の unit test を追加しやすい構造へ小さく整理する。

Closes #187

---

## ■ 変更内容

- `TaskService.UpdateTask` 内の title / dueDate / completed 反映処理を `applyUpdateTaskInput` に分離
- `UpdateTask` 本体を、更新対象チェック、対象取得、更新適用、保存の流れが見える形に整理
- repository interface や unit test は追加せず、#187 の対象範囲に限定

---

## ■ 影響範囲

- Backend の `TaskService.UpdateTask` 内部実装
- API仕様、認証挙動、DBスキーマ、frontend への影響なし

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [ ] コンソールエラーがない
* [ ] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `git diff --check`
- `cd backend && go test ./...`

補足:

- backend service 内部のリファクタリングのみのため、ブラウザでのコンソール確認は未実施
- APIを起動してのエラーケース手動確認は未実施

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: 既存の更新値反映処理を同一ファイル内の helper に移しただけで、処理順・API仕様・DBアクセス方法を変更していないため。

---

## ■ 懸念点・補足

- #185 の unit test 追加前の準備として実施
- unit test 追加、repository interface 導入、repository の `UpdateFields` 化は対象外
