### PR TITLE
TaskService.DeleteTask の unit test を追加する

### DIFF
--- a/backend/service/task_service_test.go
+++ b/backend/service/task_service_test.go
@@ -14,12 +14,15 @@ type fakeTaskRepository struct {
 
 	findErr   error
 	updateErr error
+	deleteErr error
 
 	findCalled   bool
 	updateCalled bool
+	deleteCalled bool
 	findID       uint
 	findUserID   uint
 	updatedTask  *model.Task
+	deletedTask  *model.Task
 }
 
 func (r *fakeTaskRepository) Create(task model.Task) (model.Task, error) {
@@ -50,7 +53,10 @@ func (r *fakeTaskRepository) Update(task *model.Task) error {
 }
 
 func (r *fakeTaskRepository) Delete(task *model.Task) error {
-	return nil
+	r.deleteCalled = true
+	r.deletedTask = task
+
+	return r.deleteErr
 }
 
 func TestApplyUpdateTaskInput(t *testing.T) {
@@ -245,6 +251,93 @@ func TestTaskServiceUpdateTask(t *testing.T) {
 			}
 			if tt.repo.updateCalled != tt.wantUpdateCalled {
 				t.Fatalf("expected repository update called=%v, got %v", tt.wantUpdateCalled, tt.repo.updateCalled)
+			}
+		})
+	}
+}
+
+func TestTaskServiceDeleteTask(t *testing.T) {
+	findErr := errors.New("find failed")
+	deleteErr := errors.New("delete failed")
+
+	tests := []struct {
+		name             string
+		repo             *fakeTaskRepository
+		wantAPIErrorCode string
+		wantErr          error
+		wantFindCalled   bool
+		wantDeleteCalled bool
+	}{
+		{
+			name: "taskが存在する場合は所有者チェック付きで取得して削除する",
+			repo: &fakeTaskRepository{
+				task: &model.Task{
+					Title:  "task",
+					UserID: 2,
+				},
+			},
+			wantFindCalled:   true,
+			wantDeleteCalled: true,
+		},
+		{
+			name: "taskが見つからない場合は削除せずNOT_FOUNDを返す",
+			repo: &fakeTaskRepository{
+				findErr: gorm.ErrRecordNotFound,
+			},
+			wantAPIErrorCode: apperror.CodeNotFound,
+			wantFindCalled:   true,
+			wantDeleteCalled: false,
+		},
+		{
+			name: "取得時のrepository errorは削除せずそのまま返す",
+			repo: &fakeTaskRepository{
+				findErr: findErr,
+			},
+			wantErr:          findErr,
+			wantFindCalled:   true,
+			wantDeleteCalled: false,
+		},
+		{
+			name: "削除時のrepository errorはそのまま返す",
+			repo: &fakeTaskRepository{
+				task: &model.Task{
+					Title:  "task",
+					UserID: 2,
+				},
+				deleteErr: deleteErr,
+			},
+			wantErr:          deleteErr,
+			wantFindCalled:   true,
+			wantDeleteCalled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &TaskService{Repo: tt.repo}
+
+			err := service.DeleteTask(1, 2)
+
+			if tt.wantAPIErrorCode == "" && tt.wantErr == nil && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if tt.wantAPIErrorCode != "" {
+				assertAPIErrorCode(t, err, tt.wantAPIErrorCode)
+			}
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Fatalf("expected error %v, got %v", tt.wantErr, err)
+			}
+			if tt.repo.findCalled != tt.wantFindCalled {
+				t.Fatalf("expected repository find called=%v, got %v", tt.wantFindCalled, tt.repo.findCalled)
+			}
+			if tt.wantFindCalled && (tt.repo.findID != 1 || tt.repo.findUserID != 2) {
+				t.Fatalf("expected find id=1 userID=2, got id=%d userID=%d", tt.repo.findID, tt.repo.findUserID)
+			}
+			if tt.repo.deleteCalled != tt.wantDeleteCalled {
+				t.Fatalf("expected repository delete called=%v, got %v", tt.wantDeleteCalled, tt.repo.deleteCalled)
+			}
+			if tt.wantDeleteCalled && tt.repo.deletedTask != tt.repo.task {
+				t.Fatalf("expected repository delete to receive found task")
 			}
 		})
 	}


### PR DESCRIPTION
## ■ 目的

`TaskService.DeleteTask` の主要な業務ルールに対して unit test を追加し、今後の設計改善やリファクタリング時に既存挙動を守りやすくする。

Closes #191

---

## ■ 変更内容

- `fakeTaskRepository` に delete 呼び出し記録と delete error 注入を追加
- `TaskService.DeleteTask` の以下ケースを unit test に追加
  - 削除成功
  - task 未存在時の `NOT_FOUND`
  - repository Find error
  - repository Delete error

---

## ■ 影響範囲

- Backend service unit test のみ
- production code、API仕様、認証挙動、DBスキーマへの変更なし

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [ ] コンソールエラーがない
* [x] エラーケースを確認した
 
※コンソールエラー確認は UI 変更を伴わないため対象外 

---

## ■ 確認ログ（任意）

```txt
cd backend
go test ./...
```

結果: 成功

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: unit test 追加のみで、production code や API 挙動には触れていないため。

---

## ■ 懸念点・補足

- `gh auth status` は未ログインだったため、PR 作成は GitHub connector で実施。
- コンソールエラー確認は UI 変更を伴わないため未実施。