### PR TITLE
POST /tasks の title trim 方針を反映する

### DIFF
--- a/backend/controller/task_validation.go
+++ b/backend/controller/task_validation.go
@@ -14,7 +14,7 @@ import (
 func validateCreateTaskInput(input *dto.CreateTaskInput) *apperror.APIError {
 	details := []apperror.ErrorDetail{}
 
-	details = append(details, validateTitle(input.Title)...)
+	details = append(details, validateTitle(&input.Title)...)
 	details = append(details, validateCreateDueDate(input)...)
 
 	if len(details) == 0 {
@@ -51,7 +51,7 @@ func validateUpdateTaskInput(input *dto.UpdateTaskRequest) *apperror.APIError {
 	details := []apperror.ErrorDetail{}
 
 	if input.Title != nil {
-		details = append(details, validateUpdateTitle(input)...)
+		details = append(details, validateTitle(input.Title)...)
 	}
 
 	if input.DueDate.IsSet && input.DueDate.Value != nil {
@@ -63,13 +63,6 @@ func validateUpdateTaskInput(input *dto.UpdateTaskRequest) *apperror.APIError {
 	}
 
 	return apperror.NewValidationError("validation error", details)
-}
-
-func validateUpdateTitle(input *dto.UpdateTaskRequest) []apperror.ErrorDetail {
-	trimmed := strings.TrimSpace(*input.Title)
-	input.Title = &trimmed
-
-	return validateTitle(trimmed)
 }
 
 func validateUpdateDueDate(input *dto.UpdateTaskRequest) []apperror.ErrorDetail {
@@ -100,8 +93,11 @@ func validateUpdateDueDate(input *dto.UpdateTaskRequest) []apperror.ErrorDetail 
 	return nil
 }
 
-func validateTitle(title string) []apperror.ErrorDetail {
-	if title == "" {
+func validateTitle(title *string) []apperror.ErrorDetail {
+	trimmed := strings.TrimSpace(*title)
+	*title = trimmed
+
+	if trimmed == "" {
 		return []apperror.ErrorDetail{
 			{
 				Field:   "title",
@@ -111,7 +107,7 @@ func validateTitle(title string) []apperror.ErrorDetail {
 		}
 	}
 
-	if utf8.RuneCountInString(title) > validation.TaskTitleMaxLength {
+	if utf8.RuneCountInString(trimmed) > validation.TaskTitleMaxLength {
 		return []apperror.ErrorDetail{
 			{
 				Field:   "title",

--- a/backend/controller/task_validation_test.go
+++ b/backend/controller/task_validation_test.go
@@ -30,13 +30,30 @@ func TestValidateCreateTaskInput(t *testing.T) {
 			wantDueDate: stringPtr("2026-05-11"),
 		},
 		{
-			name: "createのtitleはtrimしない",
+			name: "createのtitleはtrimする",
 			input: dto.CreateTaskInput{
 				Title:   "  task  ",
 				DueDate: nil,
 			},
-			wantTitle:   "  task  ",
+			wantTitle:   "task",
 			wantDueDate: nil,
+		},
+		{
+			name: "createのtitleはtrim後に空ならREQUIREDを返す",
+			input: dto.CreateTaskInput{
+				Title:   "   ",
+				DueDate: nil,
+			},
+			wantTitle:        "",
+			wantDueDate:      nil,
+			wantAPIErrorCode: apperror.CodeValidationError,
+			wantDetails: []apperror.ErrorDetail{
+				{
+					Field:   "title",
+					Code:    apperror.DetailRequired,
+					Message: "タイトルは必須です",
+				},
+			},
 		},
 		{
 			name: "titleが空の場合はREQUIREDを返す",

--- a/docs/api.md
+++ b/docs/api.md
@@ -317,7 +317,7 @@ Authorization: Bearer {token}
 }
 ```
 
-※ title: 最大100文字
+※ title: 前後空白は除去される。空文字・空白のみは禁止。最大100文字
 ※ dueDate: 任意（未指定または空文字の場合はnullとして扱う）  
 ※ 形式: YYYY-MM-DD
 

--- a/docs/backend_refactoring_plan.md
+++ b/docs/backend_refactoring_plan.md
@@ -78,7 +78,7 @@ Issue #136 の調査結果をもとに、backend には以下の特徴がある�
 - `POST /users` は DTO `binding` tag ではなく controller 側で validation detail を組み立てる形へ整理済み
 - `POST /tasks` / `PATCH /tasks/:id` の title validation は共通 helper を使う形へ整理済み
 - `PATCH /tasks/:id` の更新フィールド未指定、所有者チェック、not found 判定は service 側に維持
-- `POST /tasks` の title は既存どおり trim せず、`PATCH /tasks/:id` の title は既存どおり trim する
+- `POST /tasks` / `PATCH /tasks/:id` の title は trim する
 - `POST /tasks` では `dueDate` 空文字を `nil` として扱い、`PATCH /tasks/:id` では validation error として扱う仕様差分を維持
 - `POST /tasks` で title と dueDate が同時に不正な場合は、validation details が配列であることに合わせて複数 details を返す
 
@@ -244,8 +244,7 @@ validation 種別ごとの責務案：
 
 仕様差分として維持しているもの：
 
-- `POST /tasks` の title は trim せず保存する
-- `PATCH /tasks/:id` の title は trim して更新する
+- `POST /tasks` / `PATCH /tasks/:id` の title は trim する
 - `POST /tasks` の `dueDate` 空文字は `nil` として扱う
 - `PATCH /tasks/:id` の `dueDate` 空文字は validation error として扱う
 - `PATCH /tasks/:id` の `dueDate: null` は期限削除として扱う


### PR DESCRIPTION
## ■ 目的

`POST /tasks` の title も `PATCH /tasks/:id` と同様に trim し、空白のみ title を validation error として扱う。

Closes #194

---

## ■ 変更内容

- `validateTitle` で title の trim と validation をまとめて行うよう更新
- `POST /tasks` の title も validation 時に trim して DTO に書き戻すよう変更
- trim 後に空文字となる create title の unit test を追加
- create / update の title trim 方針を `docs/backend_refactoring_plan.md` に反映

---

## ■ 影響範囲

- `POST /tasks` の title validation / 保存値
- task validation helper unit test
- backend refactoring plan の仕様記録

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [ ] コンソールエラーがない
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

```txt
cd backend
go test ./...
```

結果: 成功

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Medium
* 理由: 変更範囲は小さいが、`POST /tasks` の title 前後空白の扱いが変わる API 挙動変更のため。

---

## ■ 懸念点・補足

- Issue コメントの方針に従い、create title を trim する挙動へ変更。
- dueDate、task update の title trim 挙動、API response 形式、DBスキーマは変更なし。
- コンソールエラー確認は UI 変更を伴わないため未実施。