### PR TITLE
tasks.due_date を DATE 型へ移行する

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Go、Typescript学習と個人開発のポートフォリオとして作成し�
 - dueDate未指定: 変更なし
 - dueDate: null: 期限削除
 - dueDate: 空文字は禁止
+- dueDateはDB内部ではDATE型、APIではYYYY-MM-DD文字列として扱う
 
 #### 設計意図
 
@@ -121,6 +122,7 @@ feature 外から利用する要素は `features/{feature}/index.ts` を入口�
 - `AutoMigrate` には依存しない（起動時に自動でDDL変更しない）
 - 変更時は Up/Down をセットで管理し、適用順を崩さない
 - 新規環境はマイグレーションのみで構築できる状態を維持する
+- `tasks.due_date` はDB内部ではDATE型とし、API境界では `YYYY-MM-DD | null` として扱う
 
 ## 🔗 API設計（重要ポイント）
 本アプリでは、APIレスポンスを以下の形式に統一しています。  

--- a/backend/controller/task_controller.go
+++ b/backend/controller/task_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/msubaru14/my-app-backend/dto"
@@ -29,11 +30,17 @@ func (tc *TaskController) CreateTask(c *gin.Context) {
 		return
 	}
 
+	dueDate, err := parseTaskDueDate(input.DueDate)
+	if err != nil {
+		respondAPIError(c, apperror.NewInternalServerError())
+		return
+	}
+
 	userID := c.GetUint("user_id")
 	task := model.Task{
 		Title:     input.Title,
 		Completed: false,
-		DueDate:   input.DueDate,
+		DueDate:   dueDate,
 		UserID:    userID,
 	}
 
@@ -88,10 +95,16 @@ func (tc *TaskController) UpdateTask(c *gin.Context) {
 		return
 	}
 
+	dueDate, err := parseTaskDueDate(input.DueDate.Value)
+	if err != nil {
+		respondAPIError(c, apperror.NewInternalServerError())
+		return
+	}
+
 	updateInput := service.UpdateTaskInput{
 		Title:      input.Title,
 		DueDateSet: input.DueDate.IsSet,
-		DueDate:    input.DueDate.Value,
+		DueDate:    dueDate,
 		Completed:  input.Completed,
 	}
 
@@ -136,4 +149,17 @@ func (tc *TaskController) DeleteTask(c *gin.Context) {
 	}
 
 	response.Success(c, nil)
+}
+
+func parseTaskDueDate(value *string) (*time.Time, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	parsed, err := time.Parse("2006-01-02", *value)
+	if err != nil {
+		return nil, err
+	}
+
+	return &parsed, nil
 }

--- a/backend/db/migrations/002_alter_tasks_due_date_to_date.sql
+++ b/backend/db/migrations/002_alter_tasks_due_date_to_date.sql
@@ -1,0 +1,15 @@
+-- +migrate Up
+-- Before applying this migration, check for invalid existing values:
+-- SELECT id, due_date
+-- FROM tasks
+-- WHERE due_date IS NOT NULL
+--   AND due_date !~ '^\d{4}-\d{2}-\d{2}$';
+
+ALTER TABLE tasks
+ALTER COLUMN due_date TYPE DATE
+USING NULLIF(due_date, '')::date;
+
+-- +migrate Down
+ALTER TABLE tasks
+ALTER COLUMN due_date TYPE TEXT
+USING due_date::text;

--- a/backend/dto/task_dto.go
+++ b/backend/dto/task_dto.go
@@ -20,11 +20,17 @@ type TaskResponse struct {
 }
 
 func NewTaskResponse(task *model.Task) TaskResponse {
+	var dueDate *string
+	if task.DueDate != nil {
+		formatted := task.DueDate.Format("2006-01-02")
+		dueDate = &formatted
+	}
+
 	return TaskResponse{
 		ID:        task.ID,
 		Title:     task.Title,
 		Completed: task.Completed,
-		DueDate:   task.DueDate,
+		DueDate:   dueDate,
 	}
 }
 

--- a/backend/dto/task_dto_test.go
+++ b/backend/dto/task_dto_test.go
@@ -1,0 +1,64 @@
+package dto
+
+import (
+	"testing"
+	"time"
+
+	"github.com/msubaru14/my-app-backend/model"
+)
+
+func TestNewTaskResponseDueDate(t *testing.T) {
+	tests := []struct {
+		name        string
+		dueDate     *time.Time
+		wantDueDate *string
+	}{
+		{
+			name:        "dueDateがある場合はYYYY-MM-DD形式に変換する",
+			dueDate:     datePtr("2026-05-11"),
+			wantDueDate: stringPtr("2026-05-11"),
+		},
+		{
+			name:        "dueDateがnilの場合はnilのまま返す",
+			dueDate:     nil,
+			wantDueDate: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &model.Task{
+				Title:     "task",
+				Completed: false,
+				DueDate:   tt.dueDate,
+			}
+
+			response := NewTaskResponse(task)
+
+			if !equalStringPtr(response.DueDate, tt.wantDueDate) {
+				t.Fatalf("expected dueDate %#v, got %#v", tt.wantDueDate, response.DueDate)
+			}
+		})
+	}
+}
+
+func datePtr(value string) *time.Time {
+	parsed, err := time.Parse("2006-01-02", value)
+	if err != nil {
+		panic(err)
+	}
+
+	return &parsed
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func equalStringPtr(a *string, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	return *a == *b
+}

--- a/backend/model/task.go
+++ b/backend/model/task.go
@@ -1,11 +1,15 @@
 package model
 
-import "gorm.io/gorm"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 type Task struct {
 	gorm.Model
-	Title     string  `json:"title"`
-	Completed bool    `json:"completed" gorm:"default:false"`
-	DueDate   *string `json:"dueDate" gorm:"type:text"`
-	UserID    uint    `json:"userId" gorm:"not null;index"`
+	Title     string     `json:"title"`
+	Completed bool       `json:"completed" gorm:"default:false"`
+	DueDate   *time.Time `json:"dueDate" gorm:"type:date"`
+	UserID    uint       `json:"userId" gorm:"not null;index"`
 }

--- a/backend/service/task_input.go
+++ b/backend/service/task_input.go
@@ -1,8 +1,10 @@
 package service
 
+import "time"
+
 type UpdateTaskInput struct {
 	Title      *string
 	DueDateSet bool
-	DueDate    *string
+	DueDate    *time.Time
 	Completed  *bool
 }

--- a/backend/service/task_service_test.go
+++ b/backend/service/task_service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/msubaru14/my-app-backend/model"
 	"github.com/msubaru14/my-app-backend/pkg/apperror"
@@ -66,69 +67,69 @@ func TestApplyUpdateTaskInput(t *testing.T) {
 		input         UpdateTaskInput
 		wantTitle     string
 		wantCompleted bool
-		wantDueDate   *string
+		wantDueDate   *time.Time
 	}{
 		{
 			name: "titleだけ指定した場合はtitleだけ更新する",
 			initialTask: model.Task{
 				Title:     "old title",
 				Completed: false,
-				DueDate:   stringPtr("2026-05-10"),
+				DueDate:   datePtr("2026-05-10"),
 			},
 			input: UpdateTaskInput{
 				Title: stringPtr("new title"),
 			},
 			wantTitle:     "new title",
 			wantCompleted: false,
-			wantDueDate:   stringPtr("2026-05-10"),
+			wantDueDate:   datePtr("2026-05-10"),
 		},
 		{
 			name: "completedだけ指定した場合はcompletedだけ更新する",
 			initialTask: model.Task{
 				Title:     "task",
 				Completed: false,
-				DueDate:   stringPtr("2026-05-10"),
+				DueDate:   datePtr("2026-05-10"),
 			},
 			input: UpdateTaskInput{
 				Completed: boolPtr(true),
 			},
 			wantTitle:     "task",
 			wantCompleted: true,
-			wantDueDate:   stringPtr("2026-05-10"),
+			wantDueDate:   datePtr("2026-05-10"),
 		},
 		{
 			name: "dueDateだけ指定した場合はdueDateだけ更新する",
 			initialTask: model.Task{
 				Title:     "task",
 				Completed: false,
-				DueDate:   stringPtr("2026-05-10"),
+				DueDate:   datePtr("2026-05-10"),
 			},
 			input: UpdateTaskInput{
 				DueDateSet: true,
-				DueDate:    stringPtr("2026-05-11"),
+				DueDate:    datePtr("2026-05-11"),
 			},
 			wantTitle:     "task",
 			wantCompleted: false,
-			wantDueDate:   stringPtr("2026-05-11"),
+			wantDueDate:   datePtr("2026-05-11"),
 		},
 		{
 			name: "dueDate未指定の場合は既存値を維持する",
 			initialTask: model.Task{
 				Title:     "task",
 				Completed: false,
-				DueDate:   stringPtr("2026-05-10"),
+				DueDate:   datePtr("2026-05-10"),
 			},
 			input:         UpdateTaskInput{},
 			wantTitle:     "task",
 			wantCompleted: false,
-			wantDueDate:   stringPtr("2026-05-10"),
+			wantDueDate:   datePtr("2026-05-10"),
 		},
 		{
 			name: "dueDateにnilを指定した場合は期限を削除する",
 			initialTask: model.Task{
 				Title:     "task",
 				Completed: false,
-				DueDate:   stringPtr("2026-05-10"),
+				DueDate:   datePtr("2026-05-10"),
 			},
 			input: UpdateTaskInput{
 				DueDateSet: true,
@@ -152,7 +153,7 @@ func TestApplyUpdateTaskInput(t *testing.T) {
 			if task.Completed != tt.wantCompleted {
 				t.Fatalf("expected completed %v, got %v", tt.wantCompleted, task.Completed)
 			}
-			if !equalStringPtr(task.DueDate, tt.wantDueDate) {
+			if !equalTimePtr(task.DueDate, tt.wantDueDate) {
 				t.Fatalf("expected due date %#v, got %#v", tt.wantDueDate, task.DueDate)
 			}
 		})
@@ -363,10 +364,19 @@ func boolPtr(value bool) *bool {
 	return &value
 }
 
-func equalStringPtr(a *string, b *string) bool {
+func datePtr(value string) *time.Time {
+	parsed, err := time.Parse("2006-01-02", value)
+	if err != nil {
+		panic(err)
+	}
+
+	return &parsed
+}
+
+func equalTimePtr(a *time.Time, b *time.Time) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
 
-	return *a == *b
+	return a.Equal(*b)
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -320,6 +320,7 @@ Authorization: Bearer {token}
 ※ title: 前後空白は除去される。空文字・空白のみは禁止。最大100文字
 ※ dueDate: 任意（未指定または空文字の場合はnullとして扱う）  
 ※ 形式: YYYY-MM-DD
+※ DB内部ではDATE型で保存し、APIではYYYY-MM-DD文字列として扱う
 
 
 #### レスポンス（成功）
@@ -441,6 +442,7 @@ Authorization: Bearer {token}
 ※ dueDate: 未指定の場合は更新対象外
 ※ dueDate: null の場合は期限削除
 ※ dueDate: 空文字は禁止
+※ DB内部ではDATE型で保存し、APIではYYYY-MM-DD文字列として扱う
 
 #### dueDate の扱い
 

--- a/docs/backend_design_policy.md
+++ b/docs/backend_design_policy.md
@@ -74,6 +74,23 @@ service が HTTP request DTO に依存しすぎないよう、必要な箇所か
 
 ---
 
+## ■ dueDate の扱い
+
+task の `dueDate` は、DB内部では `DATE` 型、Go model では `*time.Time` として扱う。
+
+API request / response では引き続き `YYYY-MM-DD | null` を維持する。
+controller / DTO 境界で `YYYY-MM-DD` 文字列と `time.Time` を変換し、frontend に DB 内部型を露出しない。
+
+方針：
+
+- `POST /tasks` の `dueDate` 未指定 / `null` / 空文字は期限なしとして扱う
+- `PATCH /tasks/:id` の `dueDate` 未指定は更新対象外として扱う
+- `PATCH /tasks/:id` の `dueDate: null` は期限削除として扱う
+- `PATCH /tasks/:id` の `dueDate: ""` は validation error として扱う
+- API response の `dueDate` は `YYYY-MM-DD | null` として返す
+
+---
+
 ## ■ service error の扱い
 
 現時点では service error の一括統一は行わない。

--- a/docs/backend_refactoring_plan.md
+++ b/docs/backend_refactoring_plan.md
@@ -144,7 +144,8 @@ Issue #136 の調査結果をもとに、backend には以下の特徴がある�
 - 現在のDBスキーマ定義の正本は migration とする
 - model tag は GORM の CRUD / mapping 用メタ情報として扱う
 - model tag と migration 定義の完全一致は必須条件にしない
-- 現時点で即修正が必要な不整合は見つかっていない
+- `tasks.due_date` は Issue #204 で `DATE` 型へ移行し、API 表現は `YYYY-MM-DD | null` のまま維持する
+- `model.Task.DueDate` は `*time.Time` / `type:date` とし、DTO 境界で `YYYY-MM-DD` 文字列へ変換する
 - `model.Task` の JSON tag、foreign key / association / constraint tag、`not null` tag 明示要否は必要に応じて別Issueで扱う
 
 ---
@@ -453,7 +454,7 @@ controller ごとの error response 組み立て：
 - `users.name` / `users.email` / `users.password` は model の `size:255;not null` と migration の `VARCHAR(255) NOT NULL` が一致している
 - `users.email` は model の `uniqueIndex` と migration の unique index が一致している
 - `tasks.completed` は model の `default:false` と migration の `BOOLEAN NOT NULL DEFAULT FALSE` が整合している
-- `tasks.due_date` は model の `*string` / `type:text` と migration の nullable `TEXT` が整合している
+- `tasks.due_date` は Issue #204 で migration の nullable `DATE` と model の `*time.Time` / `type:date` を整合させた
 - `tasks.user_id` は model の `not null;index` と migration の `BIGINT NOT NULL` / index が整合している
 - `gorm.Model` 由来の `deleted_at` は migration 側にも index がある
 


### PR DESCRIPTION
## ■ 目的

`tasks.due_date` を `TEXT` から `DATE` 型へ移行し、API では従来通り `dueDate: YYYY-MM-DD | null` を維持する。

Closes #204

---

## ■ 変更内容

- `tasks.due_date` を `DATE` 型へ変換する migration を追加
- `model.Task.DueDate` を `*time.Time` + `gorm:"type:date"` に変更
- request DTO は `*string` / `PatchDueDate` のまま維持
- controller で `YYYY-MM-DD` 文字列を `time.Time` に変換
- response DTO で `time.Time` を `YYYY-MM-DD` 文字列に変換
- `UpdateTaskInput.DueDate` を `*time.Time` に変更
- dueDate response 変換と service 更新処理の test を更新
- API仕様、README、backend docs に DB 内部 DATE / API 文字列維持方針を反映

---

## ■ 影響範囲

- Backend task dueDate の内部表現
- DB migration / `tasks.due_date`
- Task create / update / list の dueDate 変換
- API response の dueDate 表現

Frontend の型・UI・API 表現は変更なし。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [ ] コンソールエラーがない（対象外）
* [x] エラーケースを確認した

---

## ■ 確認ログ（任意）

- `go test ./...` 成功
- `git diff --check` 成功
- `docker compose up --build -d` 成功
- backend 起動ログで `002_alter_tasks_due_date_to_date.sql` 実行を確認
- DB schema 確認: `tasks.due_date` が `date` / nullable
- `schema_migrations` に `002_alter_tasks_due_date_to_date.sql` 記録済み
- API smoke:
  - `POST /users`: 201
  - `POST /login`: 200
  - `POST /tasks` with `dueDate: "2026-05-13"`: 201
  - `GET /tasks`: `dueDate: "2026-05-13"` を確認
  - `PATCH /tasks/:id` with `dueDate: null`: 200
  - `GET /tasks`: `dueDate: null` を確認
- 追加確認:
  - API から `dueDate: "2026-05-20"` の task 登録成功
  - 実 DB 側でも `DATE` 型で登録されていることを確認済み

未実施:

- ブラウザ UI 操作と console 確認は未実施。今回の変更は API / DB 内部表現の変更で、frontend 表現は維持しているため API smoke を優先。

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Medium
* 理由: DB migration を含むため。既存 `tasks.due_date` に不正文字列がある場合、`DATE` 変換で migration が失敗する可能性がある。migration ファイル内に事前確認 SQL をコメントとして残した。

---

## ■ 懸念点・補足

- 既存 migration `001_init_schema.sql` は変更せず、新規 migration として追加
- Down SQL は記載済みだが、現行 migration runner は rollback 実行機能を持たない
- `gh auth status` は未ログインだったため、PR 作成は GitHub connector を使用