### PR TITLE
deploy前整理: frontend API URL env化とenv手順整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,42 @@ docker compose up --build -d
 
 デプロイ時も、API仕様・認証挙動・DBスキーマを変更しない方針を維持します。
 
+### デプロイ前提の環境変数
+
+詳細は [deploy preflight notes](./docs/deploy-preflight.md) を参照してください。
+
+Frontend は Vite 標準の environment variable で API URL を切り替えます。
+
+```env
+VITE_API_BASE_URL=https://your-render-backend.example.com
+```
+
+未設定時は local development 用に `http://localhost:8080` を使用します。
+
+Backend は production frontend origin を CORS 許可 origin として設定します。
+
+```env
+FRONTEND_URL=https://your-vercel-frontend.example.com
+GIN_MODE=release
+```
+
+DB 接続は現時点では `DATABASE_URL` ではなく、以下の分割 environment variables を使用します。
+
+```env
+DB_HOST=your-neon-host
+DB_PORT=5432
+DB_USER=your-neon-user
+DB_PASSWORD=your-neon-password
+DB_NAME=your-neon-database
+```
+
+`DATABASE_URL` 対応は backend の DB 接続責務変更を伴うため、別 Issue で扱います。
+
+### マイグレーション
+
+Backend 起動時に `backend/db/migrations` 配下の migration が順に実行されます。
+Neon 初期 DB では、Render backend 起動時に DB 接続が成功すれば migration が適用されます。
+
 
 ## 📄 ライセンス
 MIT

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,3 +11,5 @@ DB_NAME=mydb
 
 #環境変数
 JWT_SECRET=mysecret
+FRONTEND_URL=http://localhost:5173
+GIN_MODE=debug

--- a/docs/deploy-preflight.md
+++ b/docs/deploy-preflight.md
@@ -1,0 +1,53 @@
+# Deploy Preflight Notes
+
+Issue #206 では、deploy 実施前の env、CORS、production build、migration 実行方式を確認する。
+実deploy、DB schema変更、API仕様変更、backendの `DATABASE_URL` 対応は扱わない。
+
+## Frontend
+
+Vercel では以下の environment variable を設定する。
+
+```env
+VITE_API_BASE_URL=https://your-render-backend.example.com
+```
+
+未設定時は local development 用に `http://localhost:8080` を使用する。
+
+## Backend
+
+Render では以下の environment variables を設定する。
+
+```env
+FRONTEND_URL=https://your-vercel-frontend.example.com
+GIN_MODE=release
+JWT_SECRET=your-secret
+DB_HOST=your-neon-host
+DB_PORT=5432
+DB_USER=your-neon-user
+DB_PASSWORD=your-neon-password
+DB_NAME=your-neon-database
+```
+
+現在の backend は `DATABASE_URL` ではなく、`DB_HOST` / `DB_PORT` / `DB_USER` / `DB_PASSWORD` / `DB_NAME` から DB 接続 DSN を組み立てる。
+`DATABASE_URL` 対応は DB 接続責務の変更を伴うため、別 Issue で扱う。
+
+## CORS
+
+Backend の CORS は `FRONTEND_URL` を許可 origin として使用する。
+Production deploy 時は、Render の `FRONTEND_URL` に Vercel の production origin を設定する。
+
+## Migration
+
+Backend 起動時に `db.RunMigrations` が実行され、`backend/db/migrations` 配下の SQL が順に適用される。
+Neon 初期 DB では、Render backend 起動時に DB 接続が成功すれば migration が実行される。
+
+## Preflight Checks
+
+Deploy 前に以下を確認する。
+
+- `frontend` の production build が成功する
+- `backend` の build と起動確認が成功する
+- `VITE_API_BASE_URL` 未設定時に localhost fallback する
+- `VITE_API_BASE_URL` 設定時に API URL が切り替わる
+- Render の `FRONTEND_URL` に Vercel origin を設定できる
+- DB 接続 env は現状の分割 env 方式で整理されている

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8080

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,7 +2,8 @@ import { ERROR_CODES } from "../constants/errorCodes";
 import type { ErrorCode } from "../constants/errorCodes";
 import { CLIENT_ERROR_CODES, ApiError } from "./errors";
 
-export const API_BASE_URL = "http://localhost:8080";
+export const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080";
 
 export const getToken = () => localStorage.getItem("token");
 


### PR DESCRIPTION
## ■ 目的

Issue #206 の deploy 前確認結果を踏まえ、frontend API URL を Vite env で切り替えられるようにし、deploy に必要な env / CORS / migration 前提を整理する。

Closes #206

---

## ■ 変更内容

- `frontend/src/lib/api.ts` の API base URL を `VITE_API_BASE_URL` ベースに変更
- env 未設定時の `http://localhost:8080` fallback を維持
- `frontend/.env.example` を追加
- `backend/.env.example` に `FRONTEND_URL` / `GIN_MODE` を追記
- `docs/deploy-preflight.md` を追加し、Vercel / Render / Neon 前提の env、CORS、migration 実行方式を整理
- README に deploy 前提の env と migration 概要を追記

---

## ■ 影響範囲

- Frontend API request の接続先決定
- deploy 前提の README / docs / env example

API 仕様、UI、backend DB 接続ロジック、CORS 実装、migration 実装は変更していない。
`DATABASE_URL` 対応は別 Issue 前提として整理のみ行った。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [ ] コンソールエラーがない(対象外)
* [ ] エラーケースを確認した(対象外)

---

## ■ 確認ログ（任意）

- `npm run build`: OK
- `VITE_API_BASE_URL=https://api.example.test npm run build`: OK
- env 設定時に生成 asset 内の API URL が `https://api.example.test` へ切り替わることを確認
- env 未設定時に生成 asset 内の API URL が `http://localhost:8080` fallback になることを確認
- `go test ./...`: OK
- `git diff --check`: OK

ブラウザ操作確認は未実施。今回の変更は UI 変更ではなく、build-time env と docs/env example の整理に限定しているため。
エラーケース確認は未実施。API error handling / API response 仕様は変更していないため。

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: 変更は frontend の API base URL 決定と deploy 前提 docs/env example に限定。localhost fallback を維持し、backend DB 接続・CORS・migration の実装変更は行っていないため。

---

## ■ 懸念点・補足

- `DATABASE_URL` 対応は backend DB 接続責務の変更を伴うため、この PR では実装しない
- Render / Neon の実接続値は commit せず、各サービスの environment variables に設定する前提
