### PR TITLE
backend DB接続をDATABASE_URL対応にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,17 +290,21 @@ FRONTEND_URL=https://your-vercel-frontend.example.com
 GIN_MODE=release
 ```
 
-DB 接続は現時点では `DATABASE_URL` ではなく、以下の分割 environment variables を使用します。
+Production DB 接続では `DATABASE_URL` を使用します。
 
 ```env
-DB_HOST=your-neon-host
-DB_PORT=5432
-DB_USER=your-neon-user
-DB_PASSWORD=your-neon-password
-DB_NAME=your-neon-database
+DATABASE_URL=postgresql://your-neon-user:your-neon-password@your-neon-host/your-neon-database?sslmode=require
 ```
 
-`DATABASE_URL` 対応は backend の DB 接続責務変更を伴うため、別 Issue で扱います。
+`DATABASE_URL` が未設定の場合、local Docker 開発用に以下の分割 environment variables から DB 接続 DSN を組み立てます。
+
+```env
+DB_HOST=db
+DB_PORT=5432
+DB_USER=user
+DB_PASSWORD=password
+DB_NAME=mydb
+```
 
 ### マイグレーション
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,8 @@
 # DB
+# Production example:
+# DATABASE_URL=postgresql://user:password@host/dbname?sslmode=require
+
+# Local Docker development fallback:
 POSTGRES_USER=user
 POSTGRES_PASSWORD=password
 POSTGRES_DB=mydb

--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -9,14 +9,17 @@ import (
 )
 
 func Connect() (*gorm.DB, error) {
-	dsn := fmt.Sprintf(
-		"host=%s user=%s password=%s dbname=%s port=%s sslmode=disable",
-		os.Getenv("DB_HOST"),
-		os.Getenv("DB_USER"),
-		os.Getenv("DB_PASSWORD"),
-		os.Getenv("DB_NAME"),
-		os.Getenv("DB_PORT"),
-	)
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		dsn = fmt.Sprintf(
+			"host=%s user=%s password=%s dbname=%s port=%s sslmode=disable",
+			os.Getenv("DB_HOST"),
+			os.Getenv("DB_USER"),
+			os.Getenv("DB_PASSWORD"),
+			os.Getenv("DB_NAME"),
+			os.Getenv("DB_PORT"),
+		)
+	}
 
 	return gorm.Open(postgres.Open(dsn), &gorm.Config{})
 }

--- a/docs/deploy-preflight.md
+++ b/docs/deploy-preflight.md
@@ -1,7 +1,7 @@
 # Deploy Preflight Notes
 
-Issue #206 では、deploy 実施前の env、CORS、production build、migration 実行方式を確認する。
-実deploy、DB schema変更、API仕様変更、backendの `DATABASE_URL` 対応は扱わない。
+Issue #206 / #208 では、deploy 実施前の env、CORS、production build、migration 実行方式を確認する。
+実deploy、DB schema変更、API仕様変更は扱わない。
 
 ## Frontend
 
@@ -21,15 +21,21 @@ Render では以下の environment variables を設定する。
 FRONTEND_URL=https://your-vercel-frontend.example.com
 GIN_MODE=release
 JWT_SECRET=your-secret
-DB_HOST=your-neon-host
-DB_PORT=5432
-DB_USER=your-neon-user
-DB_PASSWORD=your-neon-password
-DB_NAME=your-neon-database
+DATABASE_URL=postgresql://your-neon-user:your-neon-password@your-neon-host/your-neon-database?sslmode=require
 ```
 
-現在の backend は `DATABASE_URL` ではなく、`DB_HOST` / `DB_PORT` / `DB_USER` / `DB_PASSWORD` / `DB_NAME` から DB 接続 DSN を組み立てる。
-`DATABASE_URL` 対応は DB 接続責務の変更を伴うため、別 Issue で扱う。
+Production deploy では `DATABASE_URL` を DB 接続 DSN として使用する。
+`DATABASE_URL` が未設定の場合は、local Docker development 用に `DB_HOST` / `DB_PORT` / `DB_USER` / `DB_PASSWORD` / `DB_NAME` から DSN を組み立てる。
+
+Local Docker development では以下の分割 environment variables を引き続き使用する。
+
+```env
+DB_HOST=db
+DB_PORT=5432
+DB_USER=user
+DB_PASSWORD=password
+DB_NAME=mydb
+```
 
 ## CORS
 
@@ -50,4 +56,5 @@ Deploy 前に以下を確認する。
 - `VITE_API_BASE_URL` 未設定時に localhost fallback する
 - `VITE_API_BASE_URL` 設定時に API URL が切り替わる
 - Render の `FRONTEND_URL` に Vercel origin を設定できる
-- DB 接続 env は現状の分割 env 方式で整理されている
+- Production DB 接続では `DATABASE_URL` を設定できる
+- `DATABASE_URL` 未設定時は分割 env 方式に fallback する


### PR DESCRIPTION
## ■ 目的

production deploy に向けて、backend の DB 接続設定で `DATABASE_URL` を使用できるようにする。

Closes #208

---

## ■ 変更内容

- `backend/db/db.go` で `DATABASE_URL` が設定されている場合は優先して GORM 接続 DSN に使用
- `DATABASE_URL` 未設定時は既存の `DB_HOST` / `DB_PORT` / `DB_USER` / `DB_PASSWORD` / `DB_NAME` 方式へ fallback
- `backend/.env.example` に production 用 `DATABASE_URL` placeholder と local fallback の説明を追加
- README / `docs/deploy-preflight.md` を production は `DATABASE_URL`、local Docker は分割 env の方針へ更新

---

## ■ 影響範囲

- Backend DB 接続設定
- deploy 前提 docs / env example

DBスキーマ、migration runner、API仕様、CORS、frontend は変更していない。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [ ] コンソールエラーがない(対象外)
* [ ] エラーケースを確認した(対象外)

---

## ■ 確認ログ（任意）

- `go test ./...`: OK
- `go build ./...`: OK
- `git diff --check`: OK
- Docker backend 一時起動 fallback 確認: `unset DATABASE_URL; PORT=18080 timeout 5 go run .`
  - `Listening and serving HTTP on :18080` まで到達
- Docker backend 一時起動 `DATABASE_URL` 確認: `DATABASE_URL=postgresql://user:password@db:5432/mydb?sslmode=disable PORT=18081 timeout 5 go run .`
  - `Listening and serving HTTP on :18081` まで到達

Docker 一時起動は timeout で停止しているため終了コードは 1。DB 接続、migration runner、router 初期化、listen までは確認済み。

ブラウザ操作確認は未実施。今回の変更は backend DB 接続設定と docs/env example に限定しており、UI 変更を含まないため。
コンソールエラー確認は未実施。frontend 変更を含まないため。
エラーケース確認は未実施。DB 接続失敗時のエラーハンドリング仕様は変更していないため。

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: `DATABASE_URL` が設定されている場合だけ接続 DSN として使用し、未設定時は既存の分割 env 方式を維持している。migration / schema / API / CORS には触れていないため。

---

## ■ 懸念点・補足

- Neon / Render production では `DATABASE_URL` に `sslmode=require` を含める前提
- local Docker fallback DSN は既存どおり `sslmode=disable` のまま維持
- 実際の production URL や secret は commit しない
