### PR TITLE
Vercel frontend の SPA routing を修正する

### DIFF
--- a/frontend/src/features/tasks/components/TaskList.tsx
+++ b/frontend/src/features/tasks/components/TaskList.tsx
@@ -70,7 +70,7 @@ export const TaskList = () => {
   const handleLogout = () => {
     localStorage.removeItem("token");
     clearUser();
-    window.location.href = "/login";
+    navigate("/login");
   };
 
   if (!token) {

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/"
+    }
+  ]
+}


### PR DESCRIPTION
## ■ 目的

Issue #212 の Vercel frontend production UI 確認中に、logout 後の `/login` 遷移が Vercel 上で `404 NOT_FOUND` になる問題を修正する。

Closes #212

---

## ■ 変更内容

- logout 後の遷移を `window.location.href = "/login"` から React Router の `navigate("/login")` に変更
- Vercel で `/login` や `/tasks` などの direct access / reload を SPA に流すため、`frontend/vercel.json` に rewrite 設定を追加

---

## ■ 影響範囲

- Vercel production frontend の routing
- logout 後の login 画面遷移
- `/login` / `/register` / `/tasks` などの direct access / reload

API 仕様、backend、DB schema、UI 表示は変更していない。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [x] コンソールエラーがない
* [ ] エラーケースを確認した(対象外)

---

## ■ 確認ログ（任意）

- `npm run build`: OK
- Local frontend env を `VITE_API_BASE_URL=http://localhost:8080` にして frontend コンテナを再起動: OK
- Local browser check:
  - `/tasks` 表示: OK
  - logout 実行: OK
  - logout 後の遷移先: `http://localhost:5173/login`
  - token 削除: OK
  - `404` / `NOT_FOUND`: なし
  - console error / exception: なし

補足:

- Vite dev server では `/login` / `/tasks` の direct access が `200 OK` になることを curl で確認済み
- `frontend/.env` が production backend を向いている状態では localhost origin が Render CORS に許可されていないため network error が出たが、local backend 向け env に戻して再確認した結果、console error は解消

Production 上の再確認は、この PR を merge して Vercel redeploy 後に実施する。
確認予定:

- logout 後に `/login` で `404 NOT_FOUND` にならないこと
- `/login` / `/register` / `/tasks` direct access が Vercel 上で SPA として表示されること
- browser console に致命的 error がないこと
- register / login / logout / task CRUD が production backend と連携して動作すること

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: 変更は Vercel の SPA fallback 設定と logout 時の client-side navigation に限定。API 仕様や UI 表示、backend には影響しないため。

---

## ■ 懸念点・補足

- `frontend/vercel.json` は Vercel production routing 用の設定
- この PR merge 後に Vercel redeploy と production UI 再確認が必要
