### PR TITLE
README / docs を production 構成へ最終整理する

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 
 ## 🚀 デモ
 
+Production URL:
+
+- Frontend: https://my-task-app-psi-seven.vercel.app
+- Backend API: https://my-app-backend-uugs.onrender.com
+
 | ![registration](./docs/registration.png) | ![login](./docs/login.png) | ![task_list](./docs/task_list.png) | ![task_update](./docs/task_update.png) |
 | :---------------------: | :------------: | :---------------------: | :------------: |
 | ユーザ登録 | ログイン | タスク一覧 | タスク編集 |
@@ -80,7 +85,8 @@ HTTP PATCHの思想に沿い、フロントからの差分更新に柔軟に対�
 - PostgreSQL
 
 ### Infrastructure
-- Docker / Docker Compose
+- Local: Docker / Docker Compose
+- Production: Vercel / Render / Neon
 
 ## 🏗 アーキテクチャ
 レイヤードアーキテクチャを採用し、責務を分離
@@ -172,6 +178,27 @@ cd my-app
 ### 2. 環境変数設定
 ```bash
 cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
+```
+
+local development では以下を使用します。
+
+```env
+# frontend/.env
+VITE_API_BASE_URL=http://localhost:8080
+```
+
+```env
+# backend/.env
+JWT_SECRET=mysecret
+FRONTEND_URL=http://localhost:5173
+GIN_MODE=debug
+
+DB_HOST=db
+DB_PORT=5432
+DB_USER=user
+DB_PASSWORD=password
+DB_NAME=mydb
 ```
 
 ### 3. 起動
@@ -228,9 +255,7 @@ docker compose up --build -d
 
 
 ## 🚧 今後の予定
-- TaskService など業務ルールが多い箇所から unit test を小さく追加
-- service input 導入による request DTO 依存の整理
-- 無料PaaS構成でのデプロイ
+- production 運用時のログ・監視方針の整理
 - 必要に応じたUI/UX改善
 
 
@@ -259,26 +284,31 @@ docker compose up --build -d
 - backend の責務分離方針を説明できる
 - frontend の feature 分割と error handling 方針を説明できる
 - TaskService など重要な業務ルールに unit test を小さく導入している
-- 無料PaaS構成でデプロイできる状態になっている
+- 無料PaaS構成で production deploy 済みである
 
-## ☁️ デプロイ方針
+## ☁️ デプロイ構成
 
-ポートフォリオとして公開しやすいよう、無料枠で始められるPaaS構成を想定します。
+ポートフォリオとして公開しやすいよう、無料枠で始められるPaaS構成で deploy しています。
 
 - Frontend: Vercel
 - Backend: Render
 - Database: Neon
 
-デプロイ時も、API仕様・認証挙動・DBスキーマを変更しない方針を維持します。
+Production 環境でも、API仕様・認証挙動・DBスキーマを変更しない方針を維持しています。
 
-### デプロイ前提の環境変数
+### Production URL
 
-詳細は [deploy preflight notes](./docs/deploy-preflight.md) を参照してください。
+- Frontend: https://my-task-app-psi-seven.vercel.app
+- Backend API: https://my-app-backend-uugs.onrender.com
+
+### Production 環境変数
+
+詳細は [production deploy notes](./docs/deploy-preflight.md) を参照してください。
 
 Frontend は Vite 標準の environment variable で API URL を切り替えます。
 
 ```env
-VITE_API_BASE_URL=https://your-render-backend.example.com
+VITE_API_BASE_URL=https://my-app-backend-uugs.onrender.com
 ```
 
 未設定時は local development 用に `http://localhost:8080` を使用します。
@@ -286,7 +316,7 @@ VITE_API_BASE_URL=https://your-render-backend.example.com
 Backend は production frontend origin を CORS 許可 origin として設定します。
 
 ```env
-FRONTEND_URL=https://your-vercel-frontend.example.com
+FRONTEND_URL=https://my-task-app-psi-seven.vercel.app
 GIN_MODE=release
 ```
 
@@ -310,6 +340,17 @@ DB_NAME=mydb
 
 Backend 起動時に `backend/db/migrations` 配下の migration が順に実行されます。
 Neon 初期 DB では、Render backend 起動時に DB 接続が成功すれば migration が適用されます。
+
+### Production 動作確認
+
+Production 環境で以下を確認済みです。
+
+- ユーザー登録 / ログイン / ログアウト
+- タスク作成 / 一覧取得 / 更新 / 完了切替 / 削除
+- validation error 表示
+- unauthorized redirect
+- Vercel SPA routing
+- browser console に致命的 error がないこと
 
 
 ## 📄 ライセンス

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,14 @@
 
 ## ベースURL
 
+Production:
+
+```
+https://my-app-backend-uugs.onrender.com
+```
+
+Local development:
+
 ```
 http://localhost:8080
 ```

--- a/docs/backend_design_policy.md
+++ b/docs/backend_design_policy.md
@@ -167,13 +167,13 @@ unit test は一括導入せず、業務ルールが多い箇所から小さく�
 - backend の責務分離方針を説明できる
 - frontend の feature 分割と error handling 方針を説明できる
 - TaskService など重要な業務ルールに unit test を小さく導入している
-- 無料PaaS構成でデプロイできる状態になっている
+- 無料PaaS構成で production deploy 済みである
 
 ---
 
 ## ■ デプロイ方針
 
-ポートフォリオとして公開しやすいよう、無料枠で始められるPaaS構成を想定する。
+ポートフォリオとして公開しやすいよう、無料枠で始められるPaaS構成で deploy している。
 
 - Frontend: Vercel
 - Backend: Render
@@ -183,10 +183,7 @@ unit test は一括導入せず、業務ルールが多い箇所から小さく�
 
 ---
 
-## ■ 次の進め方
+## ■ 今後の改善候補
 
-1. `TaskService.UpdateTask` の service input 導入要否を検討する
-2. TaskService から unit test を小さく導入する
-3. unit test 導入時に repository interface の必要性を確認する
-4. service error 方針に基づき、実装変更が必要な箇所が出た場合は個別 Issue で扱う
-5. user / auth validation helper 分離の必要性を確認する
+1. service error 方針に基づき、実装変更が必要な箇所が出た場合は個別 Issue で扱う
+2. user / auth validation helper 分離の必要性を確認する

--- a/docs/deploy-preflight.md
+++ b/docs/deploy-preflight.md
@@ -1,24 +1,39 @@
-# Deploy Preflight Notes
+# Production Deploy Notes
 
-Issue #206 / #208 では、deploy 実施前の env、CORS、production build、migration 実行方式を確認する。
-実deploy、DB schema変更、API仕様変更は扱わない。
+production deploy の前提、環境変数、CORS、migration 実行方式、動作確認結果をまとめる。
+実際の secret / password / full `DATABASE_URL` は記載しない。
+
+## Production Structure
+
+```txt
+Frontend: Vercel
+Backend: Render
+Database: Neon
+```
+
+Production URL:
+
+- Frontend: https://my-task-app-psi-seven.vercel.app
+- Backend API: https://my-app-backend-uugs.onrender.com
 
 ## Frontend
 
 Vercel では以下の environment variable を設定する。
 
 ```env
-VITE_API_BASE_URL=https://your-render-backend.example.com
+VITE_API_BASE_URL=https://my-app-backend-uugs.onrender.com
 ```
 
 未設定時は local development 用に `http://localhost:8080` を使用する。
+
+Vercel では `frontend/vercel.json` により、`/login` / `/register` / `/tasks` などの direct access / reload を SPA に rewrite する。
 
 ## Backend
 
 Render では以下の environment variables を設定する。
 
 ```env
-FRONTEND_URL=https://your-vercel-frontend.example.com
+FRONTEND_URL=https://my-task-app-psi-seven.vercel.app
 GIN_MODE=release
 JWT_SECRET=your-secret
 DATABASE_URL=postgresql://your-neon-user:your-neon-password@your-neon-host/your-neon-database?sslmode=require
@@ -40,16 +55,16 @@ DB_NAME=mydb
 ## CORS
 
 Backend の CORS は `FRONTEND_URL` を許可 origin として使用する。
-Production deploy 時は、Render の `FRONTEND_URL` に Vercel の production origin を設定する。
+Render の `FRONTEND_URL` には Vercel の production origin を設定する。
 
 ## Migration
 
 Backend 起動時に `db.RunMigrations` が実行され、`backend/db/migrations` 配下の SQL が順に適用される。
 Neon 初期 DB では、Render backend 起動時に DB 接続が成功すれば migration が実行される。
 
-## Preflight Checks
+## Deploy Checks
 
-Deploy 前に以下を確認する。
+deploy フェーズで以下を確認済み。
 
 - `frontend` の production build が成功する
 - `backend` の build と起動確認が成功する
@@ -58,3 +73,23 @@ Deploy 前に以下を確認する。
 - Render の `FRONTEND_URL` に Vercel origin を設定できる
 - Production DB 接続では `DATABASE_URL` を設定できる
 - `DATABASE_URL` 未設定時は分割 env 方式に fallback する
+- Neon DB に `schema_migrations` / `users` / `tasks` が作成される
+- Render backend が production API として HTTP 応答する
+- Vercel frontend から Render backend / Neon DB と連携して操作できる
+
+## Production UI Checks
+
+production 環境で以下を確認済み。
+
+- register
+- login
+- logout
+- task 作成
+- task 一覧取得
+- task 更新
+- task 完了切替
+- task 削除
+- validation error 表示
+- unauthorized redirect
+- Vercel SPA routing
+- browser console に致命的 error がないこと


### PR DESCRIPTION
## ■ 目的

deploy 完了後の最終整理として、README / docs を production 構成と現在の設計方針に合わせて更新する。

Closes #214

---

## ■ 変更内容

- README に production URL、Vercel / Render / Neon 構成、production env、production 動作確認済み項目を反映
- setup 手順に `frontend/.env` 作成と local env 例を追加
- `docs/deploy-preflight.md` を production deploy notes として更新
- `docs/api.md` に production / local の base URL を併記
- `docs/backend_design_policy.md` の deploy 表現を production deploy 済みの状態へ更新
- 完了済みの TaskService unit test / service input 導入を README の今後の予定から削除

---

## ■ 影響範囲

- README / docs の説明内容
- portfolio 用の構成・設計・deploy 説明

実装、API仕様、DB schema、UI は変更していない。

---

## ■ 動作確認

* [x] 既存挙動が変わっていない
* [x] 対象機能が正常に動作する
* [ ] コンソールエラーがない(対象外)
* [ ] エラーケースを確認した(対象外)

---

## ■ 確認ログ（任意）

- `git diff --check`: OK
- 古い deploy 前提の文言検索: OK
- README / docs 内容確認: OK

アプリのテストは未実施。docs-only 変更であり、実装・API・UI を変更していないため。
ブラウザ console / エラーケース確認は未実施。同上。

---

## ■ スコープ確認

* [x] 1PR = 1目的
* [x] 目的外の変更をしていない
* [x] ロジック変更と構造整理を混ぜていない
* [x] UI変更をしていない

---

## ■ リスク評価

* リスク: Low
* 理由: README / docs の更新のみで、実装・API仕様・DB schema・UI には影響しないため。

---

## ■ 懸念点・補足

- production URL は公開URLとして README / docs に記載
- secret / password / full `DATABASE_URL` は記載していない
- `docs/codex-browser-check.md` の localhost 記述は local browser check 手順として正しいため維持
